### PR TITLE
docs(log-access): document context-history split log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ USAi delivers security and interaction logs to your dedicated AWS resources. You
 Additional guides:
 - [Complete Log Access Guide](./log-access/log-access-guide.md) - Full setup reference with Python consumer script
 - [Raw vs Redacted Logs](./log-access/raw-vs-redacted-logs.md) - Choosing between PII-redacted and full-content logs
+- [Interaction Log Schemas](./log-access/examples/) - Canonical JSON Schemas and examples for both the current and upcoming split log formats
 - [Security Best Practices](./log-access/security-best-practices.md) - Credential rotation, storage, incident response
 - [DLQ Investigation](./log-access/dlq-investigation.md) - Dead letter queue troubleshooting
 - [Architecture](./log-access/architecture.md) - How the Firehose → S3 → SNS → SQS pipeline works
+
+> **Log consumers:** the raw interaction log format is changing — conversation content moves out of the streamed event into a separate S3 object referenced by `context_history_s3_key`. See [Upcoming change: context-history split](./log-access/raw-vs-redacted-logs.md#upcoming-change-context-history-split) for the new shapes and the consumer migration checklist.
 
 ## Additional things for you to (potentially) think about
 ### Privacy policy

--- a/log-access/PII_REDACTION_COMPLETE.md
+++ b/log-access/PII_REDACTION_COMPLETE.md
@@ -106,6 +106,26 @@ Write to REDACTED bucket with renamed fields (prompt_redacted / response_redacte
 
 See [examples/interaction_redacted_event_schema.json](examples/interaction_redacted_event_schema.json) for the authoritative redacted schema.
 
+### 3. Impact of the context-history split (upcoming)
+
+The RAW stream is moving to a [context-history split](raw-vs-redacted-logs.md#upcoming-change-context-history-split),
+in which `prompt` and `response` are written to a separate S3 object instead of
+being embedded in the streamed event. That directly affects the paths listed above:
+`prompt.messages[].content[].text` and `response.choices[].content` will no longer
+exist on the streamed event, so a redactor reading only the Kinesis event has
+nothing to redact.
+
+**Not yet confirmed by the platform team** — do not assume either answer:
+
+- Whether the REDACTED pipeline also splits, or continues to emit inline
+  `prompt_redacted` / `response_redacted` content.
+- Whether the context-history document is PII-redacted for tenants on the redacted
+  path, or exists only on the raw path.
+- Whether `truncated` is retired from the redacted event as well as the raw event.
+
+This document describes the redaction behavior in production today. It will be
+updated once the split's redaction design is published.
+
 ---
 
 ## Redaction Examples

--- a/log-access/README.md
+++ b/log-access/README.md
@@ -133,6 +133,14 @@ bucket you read from: **redacted** (`prompt_redacted` / `response_redacted`) and
 **raw** (`prompt` / `response`, plus `platform_model_id` and tool data). See the
 canonical schemas and examples in [`examples/`](./examples/).
 
+> **⚠️ Upcoming change:** the RAW stream is moving to a **context-history split** —
+> streamed events will carry metadata plus a `context_history_s3_key` pointer, and
+> conversation content will live in a separate S3 object. `prompt`, `response`, and
+> `truncated` disappear from the streamed event, `usage` moves to the top level, and
+> `usage.latency_ms` may be `null`. If you are building a consumer now, read
+> [Upcoming change: context-history split](./raw-vs-redacted-logs.md#upcoming-change-context-history-split)
+> and follow the migration checklist there.
+
 **Example Event (redacted):**
 ```json
 {
@@ -163,6 +171,13 @@ canonical schemas and examples in [`examples/`](./examples/).
 - `latency_ms` is present in `response.usage` on **raw** events only.
 - Message text is a list of typed parts (`content[].text`), not a plain string.
 - **Raw** events add `platform_model_id`, `prompt.tools` / `tool_choice`, and `response.choices[].tool_calls`.
+- `source` is `"api"` for direct API traffic and `"chat"` for USAi Chat traffic.
+  Chat events carry a `conversation_id` and a UUID `user_id`; API events use an
+  api-key alias such as `api-key-<uuid>` or `local-api`.
+- **After the context-history split** (raw stream): `usage` moves to the top level,
+  `usage.latency_ms` may be `null`, `truncated` is removed, and `status` plus
+  `context_history_s3_key` are added. Content is fetched separately from
+  `context_history_s3_key`.
 
 **Common Operations:**
 ```bash
@@ -178,11 +193,21 @@ cat log.json | jq '{event_id, model, usage: .response_redacted.usage}'
 # Extract key fields (raw)
 cat log.json | jq '{event_id, model, platform_model_id, usage: .response.usage}'
 
+# Extract key fields (raw, after the context-history split)
+cat log.json | jq '{event_id, model, platform_model_id, status, usage, context_history_s3_key}'
+
 # Count by model
 cat log.json | jq -r '.model' | sort | uniq -c
 
 # Sum total tokens (redacted)
 cat log.json | jq '.response_redacted.usage.total_tokens' | paste -sd+ - | bc
+
+# Sum total tokens (raw, after the context-history split)
+cat log.json | jq '.usage.total_tokens' | paste -sd+ - | bc
+
+# Fetch the conversation content for one event (after the split)
+KEY=$(head -1 log.json | jq -r '.context_history_s3_key')
+aws s3 cp s3://${BUCKET_NAME}/${KEY} - --region ${AWS_REGION} | jq .
 ```
 
 ---

--- a/log-access/examples/README.md
+++ b/log-access/examples/README.md
@@ -1,0 +1,66 @@
+# Interaction Log Schemas and Examples
+
+Canonical JSON Schemas (draft 2020-12) and matching examples for USAi interaction
+logs. Two format generations are represented here.
+
+## Current format (in production today)
+
+Content is inline on each streamed NDJSON event.
+
+| File | Purpose |
+|---|---|
+| [`interaction_raw_event_schema.json`](interaction_raw_event_schema.json) | RAW event, content inline |
+| [`interaction_raw_event_example.json`](interaction_raw_event_example.json) | Example RAW event |
+| [`interaction_redacted_event_schema.json`](interaction_redacted_event_schema.json) | REDACTED event, content inline |
+| [`interaction_redacted_event_example.json`](interaction_redacted_event_example.json) | Example REDACTED event |
+
+## Split format (upcoming — context-history split)
+
+Each request produces a small metadata event plus a separate S3 document holding
+the conversation content. Applies to the RAW stream; the REDACTED stream's
+behavior is not yet confirmed. Cutover date not yet published.
+
+| File | Purpose |
+|---|---|
+| [`interaction_raw_metadata_event_schema.json`](interaction_raw_metadata_event_schema.json) | Metadata event with `context_history_s3_key` |
+| [`interaction_raw_metadata_event_chat_example.json`](interaction_raw_metadata_event_chat_example.json) | Example metadata event, `source: "chat"` |
+| [`interaction_raw_metadata_event_api_example.json`](interaction_raw_metadata_event_api_example.json) | Example metadata event, `source: "api"` |
+| [`interaction_context_history_schema.json`](interaction_context_history_schema.json) | The content document at `context_history_s3_key` |
+| [`interaction_context_history_chat_example.json`](interaction_context_history_chat_example.json) | Example content document, chat traffic |
+| [`interaction_context_history_api_example.json`](interaction_context_history_api_example.json) | Example content document, API traffic |
+
+Narrative documentation, the field-by-field delta, and the consumer migration
+checklist are in
+[`../raw-vs-redacted-logs.md`](../raw-vs-redacted-logs.md#upcoming-change-context-history-split).
+
+## Note on artifact shape
+
+The metadata events are **NDJSON** — one JSON object per line in the delivered S3
+object. The `*_example.json` files here are pretty-printed single objects for
+readability; a real log file has one compact object per line.
+
+The context-history documents are **single JSON documents**, not NDJSON.
+
+## Validating a sample against these schemas
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install jsonschema
+```
+
+```python
+import json
+import jsonschema
+
+schema = json.load(open("interaction_raw_metadata_event_schema.json"))
+validator = jsonschema.Draft202012Validator(schema)
+
+with open("log.json") as f:                 # NDJSON from S3
+    for lineno, line in enumerate(f, 1):
+        for err in validator.iter_errors(json.loads(line)):
+            path = "/".join(str(p) for p in err.path) or "<root>"
+            print(f"line {lineno} [{path}]: {err.message}")
+```
+
+Note that these schemas do not set `additionalProperties: false`. Unknown fields
+are allowed so that a new platform field does not break tenant validation; run the
+loop above after any platform release to spot fields worth adopting.

--- a/log-access/examples/interaction_context_history_api_example.json
+++ b/log-access/examples/interaction_context_history_api_example.json
@@ -1,0 +1,29 @@
+{
+  "user_id": "local-api",
+  "prompt": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Hello"
+          }
+        ]
+      }
+    ]
+  },
+  "response": {
+    "choices": [
+      {
+        "content": "Hello! It's nice to meet you. Is there something I can help you with or would you like to chat?",
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 36,
+      "completion_tokens": 24,
+      "total_tokens": 60
+    }
+  }
+}

--- a/log-access/examples/interaction_context_history_chat_example.json
+++ b/log-access/examples/interaction_context_history_chat_example.json
@@ -1,0 +1,90 @@
+{
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "prompt": {
+    "messages": [
+      {
+        "role": "system",
+        "content": [
+          {
+            "type": "text",
+            "text": "### purpose\nYou are a helpful assistant that works for a government agency. You are the LLM model: {{current_model}}\nYou help users with general knowledge, problem-solving, coding, ..."
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Who is the current Administrator for the General Services Administration?"
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [],
+        "tool_calls": [
+          {
+            "index": 0,
+            "id": "call_skqaxWgd2tuOUlF468FNyG1W",
+            "type": "function",
+            "function": {
+              "name": "web_search",
+              "arguments": "{\"query\":\"current Administrator of the General Services Administration GSA Administrator\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "call_skqaxWgd2tuOUlF468FNyG1W",
+        "content": "[{\"title\": \"Administrator for the General Services Administration | GSA\", \"link\": \"https://www.gsa.gov/about-gsa/organization/administrator\", \"snippet\": \"May 21, 2026 ... Ed Forst. As Administrator, Ed Forst brings 40 years of experience in managing complex organizations. ...\"}]"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "web_search",
+          "description": "Get snippets and links from Google PSE search",
+          "parameters": {
+            "properties": {
+              "query": {
+                "description": "The query to pass to Google",
+                "title": "Query",
+                "type": "string"
+              },
+              "time_limit": {
+                "anyOf": [
+                  {
+                    "enum": ["d1", "w1", "m1", "y1"],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Restrict results to a specific time. Use \"d1\" for last 24h, \"w1\" for last week, \"m1\" for last month, or \"y1\" for last year.",
+                "title": "Time Limit"
+              }
+            },
+            "required": ["query"],
+            "title": "SearchQuery",
+            "type": "object"
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto"
+  },
+  "response": {
+    "choices": [
+      {
+        "content": "The current Administrator of the General Services Administration (GSA) is **Ed Forst** \u2014 also listed as **Edward C. Forst** on GSA materials.",
+        "finish_reason": "stop"
+      }
+    ]
+  }
+}

--- a/log-access/examples/interaction_context_history_schema.json
+++ b/log-access/examples/interaction_context_history_schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GSA-TTS/usai-onboarding/log-access/examples/interaction_context_history_schema.json",
+  "title": "USAi Interaction Context History Document (split format, post-cutover)",
+  "description": "Schema for the standalone S3 object that holds the full prompt/response content for one interaction event. This is a single JSON document (NOT newline-delimited). Its key is published on the corresponding firehose metadata event as context_history_s3_key. See interaction_raw_metadata_event_schema.json.",
+  "type": "object",
+  "required": ["user_id", "prompt", "response"],
+  "properties": {
+    "user_id": {
+      "type": "string",
+      "description": "User identifier, matching user_id on the metadata event."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for chat traffic; absent for stateless API requests."
+    },
+    "prompt": {
+      "type": "object",
+      "description": "Full, unredacted request payload.",
+      "required": ["messages"],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "enum": ["system", "user", "assistant", "tool"]
+              },
+              "content": {
+                "description": "Either a string (tool results) or a list of typed content parts. May be an empty array on assistant messages that only carry tool_calls.",
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Content part type, e.g. 'text'."
+                        },
+                        "text": { "type": "string" }
+                      }
+                    }
+                  }
+                ]
+              },
+              "tool_call_id": {
+                "type": "string",
+                "description": "Present on role='tool' messages; correlates with an earlier tool_calls[].id."
+              },
+              "tool_calls": {
+                "type": "array",
+                "description": "Present on role='assistant' messages that invoke tools.",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "type", "function"],
+                  "properties": {
+                    "index": { "type": "integer" },
+                    "id": { "type": "string" },
+                    "type": { "type": "string" },
+                    "function": {
+                      "type": "object",
+                      "required": ["name", "arguments"],
+                      "properties": {
+                        "name": { "type": "string" },
+                        "arguments": {
+                          "type": "string",
+                          "description": "JSON-encoded string of the tool arguments."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tool/function definitions supplied to the model.",
+          "items": {
+            "type": "object",
+            "required": ["type", "function"],
+            "properties": {
+              "type": { "type": "string" },
+              "function": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "description": { "type": "string" },
+                  "parameters": {
+                    "type": "object",
+                    "description": "JSON Schema describing the tool's arguments."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tool_choice": {
+          "type": "string",
+          "description": "Tool selection strategy, e.g. 'auto', 'none', 'required'."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Sampling temperature for the request, when supplied."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "description": "Full, unredacted response payload.",
+      "required": ["choices"],
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": { "type": "string" },
+              "finish_reason": { "type": "string" },
+              "tool_calls": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "index": { "type": "integer" },
+                    "id": { "type": "string" },
+                    "type": { "type": "string" },
+                    "function": {
+                      "type": "object",
+                      "properties": {
+                        "name": { "type": "string" },
+                        "arguments": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "usage": {
+          "type": "object",
+          "description": "Token usage. Optional here: for chat traffic usage is carried on the metadata event instead. Read usage from the metadata event first and fall back to this field.",
+          "properties": {
+            "prompt_tokens": { "type": "integer" },
+            "completion_tokens": { "type": "integer" },
+            "total_tokens": { "type": "integer" },
+            "latency_ms": { "type": ["integer", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/log-access/examples/interaction_raw_event_schema.json
+++ b/log-access/examples/interaction_raw_event_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "USAi Interaction Raw Firehose ChatCompletion Event",
-  "description": "Schema for a single line of the interaction-raw firehose JSONL export. One JSON object per line (newline-delimited JSON). Unlike the redacted firehose, prompt/response are raw (not PII-redacted), include tool definitions, tool calls, and a platform_model_id.",
+  "title": "USAi Interaction Raw Firehose ChatCompletion Event (pre-cutover, inline content)",
+  "description": "Schema for a single line of the interaction-raw firehose JSONL export in the ORIGINAL single-object format, where prompt/response content is inline on the event. One JSON object per line (newline-delimited JSON). Unlike the redacted firehose, prompt/response are raw (not PII-redacted), include tool definitions, tool calls, and a platform_model_id. NOTE: this format is being replaced by the context-history split, in which content moves to a separate S3 object keyed by context_history_s3_key. For the new format see interaction_raw_metadata_event_schema.json and interaction_context_history_schema.json.",
   "type": "object",
   "required": [
     "event_id",
@@ -30,7 +30,7 @@
     },
     "source": {
       "type": "string",
-      "description": "Origin of the request, e.g. 'api'."
+      "description": "Origin of the request. 'chat' for USAi Chat traffic, 'api' for direct API traffic."
     },
     "stream": {
       "type": "boolean",
@@ -42,7 +42,12 @@
     },
     "user_id": {
       "type": "string",
-      "description": "User / api-key alias, e.g. 'api-key-<uuid>'."
+      "description": "User identifier. A user UUID for source='chat', or an api-key alias such as 'api-key-<uuid>' / 'local-api' for source='api'."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for source='chat'; absent for stateless source='api' requests."
     },
     "request_id": {
       "type": "string",
@@ -185,7 +190,10 @@
             "prompt_tokens": { "type": "integer" },
             "completion_tokens": { "type": "integer" },
             "total_tokens": { "type": "integer" },
-            "latency_ms": { "type": "integer" }
+            "latency_ms": {
+              "type": ["integer", "null"],
+              "description": "End-to-end latency in milliseconds. Emitted as null when not measured."
+            }
           }
         }
       }

--- a/log-access/examples/interaction_raw_metadata_event_api_example.json
+++ b/log-access/examples/interaction_raw_metadata_event_api_example.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "631241ad-d6c3-4625-94a2-880196702bdd",
+  "event_time": "2026-07-23T17:52:47.953503+00:00",
+  "source": "api",
+  "stream": false,
+  "kind": "chat_completion",
+  "user_id": "local-api",
+  "request_id": "4323c79e-1b51-4c24-9fb8-f7ac6039b84f",
+  "model": "llama_4_maverick",
+  "platform_model_id": "inference-profile/us.meta.llama4-maverick-17b-instruct-v1:0",
+  "status": "success",
+  "context_history_s3_key": "api/local-api/631241ad-d6c3-4625-94a2-880196702bdd.json"
+}

--- a/log-access/examples/interaction_raw_metadata_event_chat_example.json
+++ b/log-access/examples/interaction_raw_metadata_event_chat_example.json
@@ -1,0 +1,20 @@
+{
+  "event_id": "fd0be7bb-48d2-4376-bd4d-774a965a779d",
+  "event_time": "2026-07-23T17:46:33.705182+00:00",
+  "source": "chat",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "request_id": "20b7b796-dafa-415f-a5ae-a753678cef2c",
+  "model": "gpt-5.5",
+  "platform_model_id": "gpt-5.5-DefaultV2",
+  "usage": {
+    "prompt_tokens": 2237,
+    "completion_tokens": 38,
+    "total_tokens": 2275,
+    "latency_ms": null
+  },
+  "status": "success",
+  "context_history_s3_key": "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json"
+}

--- a/log-access/examples/interaction_raw_metadata_event_schema.json
+++ b/log-access/examples/interaction_raw_metadata_event_schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GSA-TTS/usai-onboarding/log-access/examples/interaction_raw_metadata_event_schema.json",
+  "title": "USAi Interaction Raw Metadata Event (split format, post-cutover)",
+  "description": "Schema for a single line of the interaction-raw firehose JSONL export AFTER the context-history split. One JSON object per line (newline-delimited JSON). This event carries only request metadata and token usage; the prompt/response content lives in a separate S3 object identified by context_history_s3_key and described by interaction_context_history_schema.json. For the pre-cutover single-object format see interaction_raw_event_schema.json.",
+  "type": "object",
+  "required": [
+    "event_id",
+    "event_time",
+    "source",
+    "stream",
+    "kind",
+    "user_id",
+    "request_id",
+    "model",
+    "platform_model_id",
+    "status",
+    "context_history_s3_key"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the event. Also used as the final path segment of context_history_s3_key."
+    },
+    "event_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp, e.g. 2026-07-23T17:46:33.705182+00:00."
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the request. 'chat' for USAi Chat traffic, 'api' for direct API traffic.",
+      "examples": ["chat", "api"]
+    },
+    "stream": {
+      "type": "boolean",
+      "description": "Whether the response was streamed."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Event kind, e.g. 'chat_completion'."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "User identifier. A user UUID for source='chat', or an api-key alias such as 'api-key-<uuid>' / 'local-api' for source='api'."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for source='chat'; absent for stateless source='api' requests. Used as a path segment of context_history_s3_key for chat traffic."
+    },
+    "request_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the request."
+    },
+    "model": {
+      "type": "string",
+      "description": "Model alias, e.g. 'gpt-5.5', 'llama_4_maverick', 'claude-sonnet-4.6'."
+    },
+    "platform_model_id": {
+      "type": "string",
+      "description": "Underlying platform model id, e.g. 'gpt-5.5-DefaultV2' or 'inference-profile/us.meta.llama4-maverick-17b-instruct-v1:0'."
+    },
+    "status": {
+      "type": "string",
+      "description": "Outcome of the request, e.g. 'success'. Treat as an open string set; do not assume a closed enum."
+    },
+    "context_history_s3_key": {
+      "type": "string",
+      "description": "S3 object key of the context-history document holding the full prompt/response for this event. Chat traffic: 'chat/{conversation_id}/{event_id}.json'. API traffic: 'api/{user_id}/{event_id}.json'.",
+      "examples": [
+        "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json",
+        "api/local-api/631241ad-d6c3-4625-94a2-880196702bdd.json"
+      ]
+    },
+    "usage": {
+      "type": "object",
+      "description": "Token usage for the request. In the split format usage is emitted on the metadata event for chat traffic. For some API traffic usage is instead present inside the context-history document at response.usage, so consumers should read usage from the metadata event and fall back to the context document. See 'Token usage location' in raw-vs-redacted-logs.md.",
+      "properties": {
+        "prompt_tokens": { "type": "integer" },
+        "completion_tokens": { "type": "integer" },
+        "total_tokens": { "type": "integer" },
+        "latency_ms": {
+          "type": ["integer", "null"],
+          "description": "End-to-end latency in milliseconds. Emitted as null when not measured."
+        }
+      }
+    }
+  }
+}

--- a/log-access/examples/interaction_redacted_event_schema.json
+++ b/log-access/examples/interaction_redacted_event_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "USAI interaction - redacted s3 logs Schema",
-  "description": "Schema for a single line of the USAI firehose JSONL export. The file contains one JSON object per line (newline-delimited JSON), each representing a redacted chat_completion event.",
+  "title": "USAI interaction - redacted s3 logs Schema (pre-cutover, inline content)",
+  "description": "Schema for a single line of the USAI redacted firehose JSONL export. The file contains one JSON object per line (newline-delimited JSON), each representing a redacted chat_completion event with inline redacted content. NOTE: the raw stream is moving to a context-history split (see interaction_raw_metadata_event_schema.json). Whether the redacted stream also splits is not yet confirmed; see 'Upcoming change' in raw-vs-redacted-logs.md.",
   "type": "object",
   "required": [
     "event_id",
@@ -29,7 +29,7 @@
     },
     "source": {
       "type": "string",
-      "description": "Origin of the request, e.g. 'api'."
+      "description": "Origin of the request. 'chat' for USAi Chat traffic, 'api' for direct API traffic."
     },
     "stream": {
       "type": "boolean",
@@ -41,7 +41,12 @@
     },
     "user_id": {
       "type": "string",
-      "description": "Redacted user/api-key alias, e.g. 'api-key-<uuid>'."
+      "description": "User identifier. A user UUID for source='chat', or an api-key alias such as 'api-key-<uuid>' / 'local-api' for source='api'."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for source='chat'; absent for stateless source='api' requests."
     },
     "request_id": {
       "type": "string",

--- a/log-access/examples/validate_examples.py
+++ b/log-access/examples/validate_examples.py
@@ -1,0 +1,43 @@
+"""Validate log-access example documents against their schemas.
+
+Static/local validation. Run:
+    /tmp/pr13/venv/bin/python log-access/examples/validate_examples.py
+"""
+import json
+import os
+import sys
+
+import jsonschema
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+PAIRS = [
+    ("interaction_raw_event_schema.json", "interaction_raw_event_example.json"),
+    ("interaction_redacted_event_schema.json", "interaction_redacted_event_example.json"),
+    ("interaction_raw_metadata_event_schema.json", "interaction_raw_metadata_event_chat_example.json"),
+    ("interaction_raw_metadata_event_schema.json", "interaction_raw_metadata_event_api_example.json"),
+    ("interaction_context_history_schema.json", "interaction_context_history_chat_example.json"),
+    ("interaction_context_history_schema.json", "interaction_context_history_api_example.json"),
+]
+
+
+def main():
+    failures = 0
+    for schema_name, example_name in PAIRS:
+        schema = json.load(open(os.path.join(HERE, schema_name)))
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+        doc = json.load(open(os.path.join(HERE, example_name)))
+        errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+        status = "OK  " if not errors else "FAIL"
+        print(f"{status} {example_name} -> {schema_name}")
+        for err in errors:
+            path = "/".join(str(p) for p in err.path) or "<root>"
+            print(f"       [{path}] {err.message}")
+        failures += len(errors)
+    print("\nfailures:", failures)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/log-access/log-access-guide.md
+++ b/log-access/log-access-guide.md
@@ -397,6 +397,14 @@ python consume_logs.py
 
 Log files are in **NDJSON** (Newline Delimited JSON) format, optionally gzip-compressed.
 
+> **⚠️ Upcoming change — context-history split.** The RAW stream is changing so that
+> conversation content is written to a **separate S3 object** rather than embedded in
+> the streamed event. Firehose delivery, bucket, and dated prefix stay the same, but
+> `prompt`, `response`, and `truncated` leave the event; `status`,
+> `context_history_s3_key`, and a top-level `usage` are added. See
+> [Context-history split](#context-history-split-upcoming) below and the
+> [migration checklist](raw-vs-redacted-logs.md#migration-checklist-for-consumers).
+
 ### File Naming Pattern
 
 ```
@@ -404,6 +412,14 @@ Log files are in **NDJSON** (Newline Delimited JSON) format, optionally gzip-com
 ```
 
 Example: `2026/01/28/10-30-00-abc123def456.json`
+
+After the context-history split there is a second, separately keyed artifact per
+request holding the conversation content:
+
+```
+chat/{conversation_id}/{event_id}.json      # source = "chat"
+api/{user_id}/{event_id}.json               # source = "api"
+```
 
 ### File Contents
 
@@ -462,6 +478,77 @@ Each line is a JSON object representing one analytics event.
 ```
 
 **See [raw-vs-redacted-logs.md](raw-vs-redacted-logs.md) for detailed comparison, and [examples/](examples/) for the full JSON Schemas.**
+
+### Context-history split (upcoming)
+
+**Status:** announced by the platform team; cutover date not yet published. Applies
+to the RAW stream. Whether the REDACTED stream also splits is not yet confirmed.
+
+After the split, each request produces **two** artifacts.
+
+**1. Metadata event** — one NDJSON line in the same dated prefix as today
+(schema: [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json)):
+
+```json
+{
+  "event_id": "fd0be7bb-48d2-4376-bd4d-774a965a779d",
+  "event_time": "2026-07-23T17:46:33.705182+00:00",
+  "source": "chat",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "request_id": "20b7b796-dafa-415f-a5ae-a753678cef2c",
+  "model": "gpt-5.5",
+  "platform_model_id": "gpt-5.5-DefaultV2",
+  "usage": { "prompt_tokens": 2237, "completion_tokens": 38, "total_tokens": 2275, "latency_ms": null },
+  "status": "success",
+  "context_history_s3_key": "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json"
+}
+```
+
+**2. Context-history document** — a single JSON document (not NDJSON) at
+`context_history_s3_key`, holding `prompt` and `response`
+(schema: [`interaction_context_history_schema.json`](examples/interaction_context_history_schema.json)).
+
+**Fetching content for an event:**
+
+```bash
+KEY=$(head -1 log.json | jq -r '.context_history_s3_key')
+aws s3 cp s3://${BUCKET_NAME}/${KEY} ./context.json --region ${AWS_REGION}
+jq '.prompt.messages[-1], .response.choices[0].content' context.json
+```
+
+```python
+import json
+import boto3
+
+s3 = boto3.client("s3")
+
+def load_context(bucket, event):
+    """Fetch the conversation content for a split-format metadata event."""
+    key = event.get("context_history_s3_key")
+    if not key:
+        # Pre-cutover event: content is inline.
+        return {"prompt": event.get("prompt"), "response": event.get("response")}
+    body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+    return json.loads(body)
+
+def token_usage(bucket, event):
+    """usage lives on the metadata event; fall back to the context document."""
+    usage = event.get("usage") or {}
+    if usage.get("total_tokens") is None:
+        usage = (load_context(bucket, event).get("response") or {}).get("usage", {})
+    return usage
+```
+
+The helper above handles both formats, so you can deploy it before cutover.
+
+**IAM note:** if your read policy was scoped to the dated
+`{YEAR}/{MONTH}/{DAY}/*` prefix, it will not cover `chat/*` and `api/*`. Request an
+updated policy from [usai-security@gsa.gov](mailto:usai-security@gsa.gov) before
+cutover. Whether the context-history documents land in the same bucket is one of
+the [open questions](raw-vs-redacted-logs.md#open-questions).
 
 ### Processing Log Files
 

--- a/log-access/raw-vs-redacted-logs.md
+++ b/log-access/raw-vs-redacted-logs.md
@@ -2,6 +2,13 @@
 
 **Choose which log bucket to access based on your needs.**
 
+> **Upcoming change — context-history split.** The RAW interaction stream is
+> changing so that conversation content is written to a separate S3 object
+> instead of being embedded in the streamed event. Existing consumers must be
+> updated. See [Upcoming change: context-history split](#upcoming-change-context-history-split)
+> below for the new shapes, the migration steps, and what is still unconfirmed.
+> Everything above that section describes the format in production today.
+
 ---
 
 ## Two Options
@@ -121,6 +128,149 @@
 | **Tools / tool_calls** | No | Yes |
 | **User IDs / Timestamps** | Yes | Yes |
 | **Security requirement** | Standard | Strict |
+
+---
+
+## Upcoming change: context-history split
+
+**Status:** announced by the platform team; cutover date not yet published.
+**Applies to:** the RAW interaction stream. Whether the REDACTED stream also
+splits is **not yet confirmed** — see [Open questions](#open-questions) below.
+
+### Why it is changing
+
+As conversation contexts grew, the logged items became too large for Kinesis to
+carry reliably. After the change, Kinesis still delivers one event per request to
+the same bucket and prefix layout, but that event no longer contains the chat/API
+content. The content is written separately to S3, and its location is published on
+the event as `context_history_s3_key`.
+
+Benefits:
+- Analytics that only need token usage or model selection process far less data.
+- No more failures when writing very large objects.
+
+### What each request produces after the split
+
+| Artifact | Delivered via | Location | Schema |
+|---|---|---|---|
+| **1. Metadata event** | Kinesis Firehose → S3 (unchanged prefix, NDJSON) | `{YEAR}/{MONTH}/{DAY}/{TIMESTAMP}-{UUID}.json` | [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json) |
+| **2. Context-history document** | Written directly to S3 (single JSON doc, not NDJSON) | `chat/{conversation_id}/{event_id}.json` or `api/{user_id}/{event_id}.json` | [`interaction_context_history_schema.json`](examples/interaction_context_history_schema.json) |
+
+### Metadata event (item 1)
+
+Content fields (`prompt`, `response`) and `truncated` are **gone**. New fields:
+`status`, `context_history_s3_key`, top-level `usage`, and `conversation_id` for
+chat traffic.
+
+```json
+{
+  "event_id": "fd0be7bb-48d2-4376-bd4d-774a965a779d",
+  "event_time": "2026-07-23T17:46:33.705182+00:00",
+  "source": "chat",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "request_id": "20b7b796-dafa-415f-a5ae-a753678cef2c",
+  "model": "gpt-5.5",
+  "platform_model_id": "gpt-5.5-DefaultV2",
+  "usage": { "prompt_tokens": 2237, "completion_tokens": 38, "total_tokens": 2275, "latency_ms": null },
+  "status": "success",
+  "context_history_s3_key": "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json"
+}
+```
+
+Full examples: [chat](examples/interaction_raw_metadata_event_chat_example.json),
+[api](examples/interaction_raw_metadata_event_api_example.json).
+
+### Context-history document (item 2)
+
+Fetched from the key above. Holds `prompt` (with `messages`, `tools`,
+`tool_choice`) and `response` (with `choices`), plus `user_id` and, for chat
+traffic, `conversation_id`.
+
+```json
+{
+  "user_id": "local-api",
+  "prompt": {
+    "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Hello" } ] } ]
+  },
+  "response": {
+    "choices": [ { "content": "Hello! It's nice to meet you...", "finish_reason": "stop" } ],
+    "usage": { "prompt_tokens": 36, "completion_tokens": 24, "total_tokens": 60 }
+  }
+}
+```
+
+Full examples: [chat](examples/interaction_context_history_chat_example.json),
+[api](examples/interaction_context_history_api_example.json).
+
+### Token usage location
+
+Read `usage` **from the metadata event first, then fall back to the
+context-history document** at `response.usage`. In the samples published by the
+platform team, chat traffic carries `usage` on the metadata event with no `usage`
+in the context document, while an API sample carried `usage` only inside the
+context document. Until that is reconciled, defensive reads are required:
+
+```bash
+# Token totals from metadata events, falling back is not possible in one pass —
+# read the metadata event value and treat null/absent as "fetch the context doc".
+jq -c '{event_id, model, total: (.usage.total_tokens // null),
+        context_history_s3_key}' log.json
+```
+
+```python
+usage = event.get("usage") or {}
+if not usage.get("total_tokens"):
+    ctx = json.load(s3.get_object(Bucket=bucket, Key=event["context_history_s3_key"])["Body"])
+    usage = ctx.get("response", {}).get("usage", {})
+```
+
+### Field-by-field delta (RAW stream)
+
+| Field | Before (inline) | After (split) |
+|---|---|---|
+| `prompt` / `response` | On the event | Moved to the context-history document |
+| `truncated` | Required on the event | Removed (the split makes truncation unnecessary) |
+| `usage` | `response.usage` | Top-level `usage` on the metadata event (fall back to `response.usage` in the context doc) |
+| `usage.latency_ms` | Integer | Integer **or `null`** |
+| `status` | Not present | New, e.g. `"success"` |
+| `context_history_s3_key` | Not present | New; pointer to the content object |
+| `conversation_id` | Undocumented but emitted for chat | Documented; also a path segment of the content key |
+| `event_id`, `event_time`, `source`, `stream`, `kind`, `user_id`, `request_id`, `model`, `platform_model_id` | Unchanged | Unchanged |
+
+### Migration checklist for consumers
+
+1. Stop requiring `prompt`, `response`, and `truncated` on streamed events.
+2. Read `usage` from the top level, with a fallback to the context document.
+3. Allow `usage.latency_ms` to be `null`.
+4. Add a second S3 `GetObject` for `context_history_s3_key` wherever you need
+   conversation content. Handle a missing or not-yet-written object with a retry.
+5. Update any jq/SQL/Glue/Athena projections that reference `.response.usage`,
+   `.prompt.messages`, or `truncated`.
+6. Confirm your IAM policy grants `s3:GetObject` on the `chat/*` and `api/*`
+   prefixes, not only the dated `{YEAR}/{MONTH}/{DAY}/*` prefix. If your policy
+   was scoped to the dated prefix, request an updated policy before cutover.
+
+### Open questions
+
+These are unresolved with the platform team; this guide will be updated when they
+are answered. Do not assume an answer.
+
+1. **Cutover date**, and whether old-format and new-format objects will coexist
+   in the same prefix during a transition window.
+2. **Canonical `usage` location** — metadata event, context document, or both.
+3. **Redacted stream** — does it split too, and is the context-history document
+   PII-redacted for the redacted tenant path?
+4. **Bucket and prefix** for context-history documents: same bucket as the
+   metadata events, or a separate bucket? This determines whether already-issued
+   tenant IAM policies need to change.
+5. **`status` values** — the full set, and whether `truncated` is fully retired.
+6. **Retention and SQS notifications** for context-history objects — are S3
+   event notifications emitted for them, or only for the firehose objects?
+
+Questions or migration help: [usai-security@gsa.gov](mailto:usai-security@gsa.gov).
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the upcoming **context-history split** in the raw interaction log format, where conversation content moves out of the streamed Kinesis event into a separate S3 object referenced by `context_history_s3_key`.

**Stacked on #13** (base: `log-current-aug92026`). #13 documents the format in production today and is accurate for it; this PR adds the next-generation format alongside it. Merge #13 first.

### Why

I validated #13's schemas against the platform team's published split-format samples. The current raw schema **rejects** the new metadata event:

```
'prompt' is a required property
'response' is a required property
'truncated' is a required property
undocumented top-level fields: context_history_s3_key, conversation_id, status, usage
```

Additional discrepancies found: `usage.latency_ms` is typed `integer` but real samples emit `null`; `usage` relocates from `response.usage` to the top level, breaking the documented jq recipes; `source: "chat"` and `conversation_id` were emitted but undocumented (0 grep hits across `log-access/`).

### Changes

**New schemas + examples** (from the platform team's samples, verbatim):
- `interaction_raw_metadata_event_schema.json` — the metadata event with `context_history_s3_key`, `status`, top-level `usage`, `conversation_id`
- `interaction_context_history_schema.json` — the separate content document
- Chat and API examples for each (4 files)
- `examples/README.md` indexing both format generations
- `examples/validate_examples.py` — validates every example against its schema

**Existing schemas** — marked pre-cutover, plus correctness fixes that apply today:
- `usage.latency_ms` becomes `["integer", "null"]`
- `conversation_id` documented on both raw and redacted event schemas
- `source` described as `chat` or `api`; `user_id` shapes documented (UUID for chat, `api-key-<uuid>` / `local-api` for api)

**Docs:**
- `raw-vs-redacted-logs.md` — new "Upcoming change: context-history split" section: both artifact shapes, field-by-field delta table, token-usage read-order guidance, 6-step consumer migration checklist, 6 open questions
- `log-access-guide.md` — second artifact's key patterns (`chat/{conversation_id}/{event_id}.json`, `api/{user_id}/{event_id}.json`), a format-agnostic Python helper that works before and after cutover, and the IAM prefix implication
- `PII_REDACTION_COMPLETE.md` — notes that the documented redaction paths will not exist on the split event
- `log-access/README.md` and top-level `README.md` — pointers and post-split jq recipes

### Unresolved — needs platform team input

Documented as explicit open questions rather than guessed:

1. **Cutover date**, and whether both formats coexist in one prefix during transition.
2. **Canonical `usage` location.** The samples are inconsistent: the chat sample has `usage` on the metadata event and none in the context doc; the API sample has `usage` only inside the context doc at `response.usage`. Docs currently instruct consumers to read the metadata event first and read the context document if absent — please confirm or correct.
3. **Redacted stream** — does it split too, and is the context document PII-redacted?
4. **Bucket/prefix for context documents** — same bucket? This determines whether already-issued tenant IAM policies need updating before cutover. Docs currently warn tenants to check.
5. **`status` value set**, and whether `truncated` is fully retired.
6. **S3 event notifications** for context objects — emitted, or firehose objects only?

I will update the docs once these are answered.

### Validation

**Level: static/local.** No live S3, Kinesis, or CI run.

- `log-access/examples/validate_examples.py` — 6/6 example-to-schema pairs pass, 0 failures (`jsonschema` Draft 2020-12)
- Cross-generation checks: new schema accepts both split samples (0 errors); pre-cutover schema accepts the pre-cutover sample (0 errors); each schema rejects the other generation with exactly the documented errors
- `usage.latency_ms: null` now accepted (was rejected)
- Relative-link and anchor checker: 0 broken links across the 6 touched docs
- `git diff --check`: clean; all diffs additive, no trailing-newline churn

Not validated: that the split format matches what the pipeline will actually emit — the docs reflect the samples as published.
