### PR TITLE
docs(log-access): sync interaction log docs with real schemas and document context-history split

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ USAi delivers security and interaction logs to your dedicated AWS resources. You
 Additional guides:
 - [Complete Log Access Guide](./log-access/log-access-guide.md) - Full setup reference with Python consumer script
 - [Raw vs Redacted Logs](./log-access/raw-vs-redacted-logs.md) - Choosing between PII-redacted and full-content logs
+- [Interaction Log Schemas](./log-access/examples/) - Canonical JSON Schemas and examples for both the current and upcoming split log formats
 - [Security Best Practices](./log-access/security-best-practices.md) - Credential rotation, storage, incident response
 - [DLQ Investigation](./log-access/dlq-investigation.md) - Dead letter queue troubleshooting
 - [Architecture](./log-access/architecture.md) - How the Firehose → S3 → SNS → SQS pipeline works
+
+> **Log consumers:** the raw interaction log format is changing — conversation content moves out of the streamed event into a separate S3 object referenced by `context_history_s3_key`. See [Upcoming change: context-history split](./log-access/raw-vs-redacted-logs.md#upcoming-change-context-history-split) for the new shapes and the consumer migration checklist.
 
 ## Additional things for you to (potentially) think about
 ### Privacy policy

--- a/log-access/PII_REDACTION_COMPLETE.md
+++ b/log-access/PII_REDACTION_COMPLETE.md
@@ -75,47 +75,56 @@ RAW S3 Bucket → Batch Processor → REDACTED S3 Bucket
     ↓
 Read NDJSON files
     ↓
-Extract text from "prompt" and "response" fields
+Extract text from "prompt.messages[].content[].text" and "response.choices[].content"
     ↓
 Apply regex patterns to detect PII
     ↓
-Replace PII with placeholder tags (e.g., <PERSON>)
+Replace PII with placeholder tags (e.g., <PERSON>, <PHONE>)
     ↓
-Track original and redacted lengths
-    ↓
-Write to REDACTED bucket with renamed fields
+Write to REDACTED bucket with renamed fields (prompt_redacted / response_redacted)
 ```
 
 ### 2. Fields Processed
 
 **Text fields redacted (default):**
-- `prompt.content` → renamed to `prompt_redacted.content`
-- `response.content` → renamed to `response_redacted.content`
+- `prompt.messages[].content[].text` → renamed to `prompt_redacted.messages[].content[].text`
+- `response.choices[].content` → renamed to `response_redacted.choices[].content`
 
 **Fields NOT redacted (preserved):**
-- `user_id` (UUID) - preserved for analytics
-- `chat_id` (UUID) - preserved for session tracking
+- `user_id` (api-key alias) - preserved for analytics
+- `request_id` (UUID) - preserved for request tracking
 - `event_id` - preserved for correlation
 - `event_time` - timestamp preserved
+- `source`, `stream`, `kind`, `truncated` - metadata preserved
 - `model` - model name preserved
-- `latency_ms` - performance metric preserved
-- `tokens_prompt` - token count preserved
-- `tokens_response` - token count preserved
+- `response_redacted.usage` - token counts (`prompt_tokens`, `completion_tokens`, `total_tokens`) preserved
 
-### 3. Length Tracking
+**Fields dropped in redacted logs:**
+- `platform_model_id` - raw only
+- `prompt.tools` / `tool_choice` and `response.choices[].tool_calls` - raw only
+- `usage.latency_ms` - raw only
 
-The system adds metadata fields:
+See [examples/interaction_redacted_event_schema.json](examples/interaction_redacted_event_schema.json) for the authoritative redacted schema.
 
-```json
-{
-  "prompt_original_length": 157,
-  "prompt_redacted_length": 33,
-  "response_original_length": 686,
-  "response_redacted_length": 267
-}
-```
+### 3. Impact of the context-history split (upcoming)
 
-**Purpose:** Allows analysis of content density without seeing actual content
+The RAW stream is moving to a [context-history split](raw-vs-redacted-logs.md#upcoming-change-context-history-split),
+in which `prompt` and `response` are written to a separate S3 object instead of
+being embedded in the streamed event. That directly affects the paths listed above:
+`prompt.messages[].content[].text` and `response.choices[].content` will no longer
+exist on the streamed event, so a redactor reading only the Kinesis event has
+nothing to redact.
+
+**Not yet confirmed by the platform team** — do not assume either answer:
+
+- Whether the REDACTED pipeline also splits, or continues to emit inline
+  `prompt_redacted` / `response_redacted` content.
+- Whether the context-history document is PII-redacted for tenants on the redacted
+  path, or exists only on the raw path.
+- Whether `truncated` is retired from the redacted event as well as the raw event.
+
+This document describes the redaction behavior in production today. It will be
+updated once the split's redaction design is published.
 
 ---
 

--- a/log-access/README.md
+++ b/log-access/README.md
@@ -128,19 +128,56 @@ head -5 log.json | jq .
 
 **Format:** NDJSON (one JSON object per line)
 
-**Example Event:**
+Each line is a `chat_completion` event. There are two shapes depending on which
+bucket you read from: **redacted** (`prompt_redacted` / `response_redacted`) and
+**raw** (`prompt` / `response`, plus `platform_model_id` and tool data). See the
+canonical schemas and examples in [`examples/`](./examples/).
+
+> **⚠️ Upcoming change:** the RAW stream is moving to a **context-history split** —
+> streamed events will carry metadata plus a `context_history_s3_key` pointer, and
+> conversation content will live in a separate S3 object. `prompt`, `response`, and
+> `truncated` disappear from the streamed event, `usage` moves to the top level, and
+> `usage.latency_ms` may be `null`. If you are building a consumer now, read
+> [Upcoming change: context-history split](./raw-vs-redacted-logs.md#upcoming-change-context-history-split)
+> and follow the migration checklist there.
+
+**Example Event (redacted):**
 ```json
 {
-  "event_id": "abc-123",
-  "event_time": "2026-02-17T10:30:00Z",
+  "event_id": "6e111d4e-928a-40fa-8bd9-8448637e9a6a",
+  "event_time": "2026-04-28T06:01:22.670432+00:00",
+  "source": "api",
+  "stream": false,
   "kind": "chat_completion",
-  "user_id": "user-456",
-  "model": "claude-sonnet-4",
-  "tokens_prompt": 21,
-  "tokens_response": 150,
-  "latency_ms": 250
+  "user_id": "api-key-abcd",
+  "request_id": "a29e5dc8-a5ff-426e-b127-3b3e7716b09c",
+  "model": "gemini-2.5-pro",
+  "truncated": false,
+  "prompt_redacted": {
+    "messages": [
+      { "role": "user", "content": [ { "type": "text", "text": "... contact <PHONE> ..." } ] }
+    ],
+    "temperature": 0.0
+  },
+  "response_redacted": {
+    "choices": [ { "content": "...", "finish_reason": "stop" } ],
+    "usage": { "prompt_tokens": 9848, "completion_tokens": 206, "total_tokens": 11855 }
+  }
 }
 ```
+
+**Field notes:**
+- Token counts live under `usage`: `prompt_tokens`, `completion_tokens`, `total_tokens`.
+- `latency_ms` is present in `response.usage` on **raw** events only.
+- Message text is a list of typed parts (`content[].text`), not a plain string.
+- **Raw** events add `platform_model_id`, `prompt.tools` / `tool_choice`, and `response.choices[].tool_calls`.
+- `source` is `"api"` for direct API traffic and `"chat"` for USAi Chat traffic.
+  Chat events carry a `conversation_id` and a UUID `user_id`; API events use an
+  api-key alias such as `api-key-<uuid>` or `local-api`.
+- **After the context-history split** (raw stream): `usage` moves to the top level,
+  `usage.latency_ms` may be `null`, `truncated` is removed, and `status` plus
+  `context_history_s3_key` are added. Content is fetched separately from
+  `context_history_s3_key`.
 
 **Common Operations:**
 ```bash
@@ -150,11 +187,27 @@ head -5 log.json | jq .
 # Count events
 wc -l log.json
 
-# Extract specific fields
-cat log.json | jq '{event_id, model, tokens_prompt, tokens_response}'
+# Extract key fields (redacted)
+cat log.json | jq '{event_id, model, usage: .response_redacted.usage}'
+
+# Extract key fields (raw)
+cat log.json | jq '{event_id, model, platform_model_id, usage: .response.usage}'
+
+# Extract key fields (raw, after the context-history split)
+cat log.json | jq '{event_id, model, platform_model_id, status, usage, context_history_s3_key}'
 
 # Count by model
 cat log.json | jq -r '.model' | sort | uniq -c
+
+# Sum total tokens (redacted)
+cat log.json | jq '.response_redacted.usage.total_tokens' | paste -sd+ - | bc
+
+# Sum total tokens (raw, after the context-history split)
+cat log.json | jq '.usage.total_tokens' | paste -sd+ - | bc
+
+# Fetch the conversation content for one event (after the split)
+KEY=$(head -1 log.json | jq -r '.context_history_s3_key')
+aws s3 cp s3://${BUCKET_NAME}/${KEY} - --region ${AWS_REGION} | jq .
 ```
 
 ---

--- a/log-access/examples/README.md
+++ b/log-access/examples/README.md
@@ -1,0 +1,66 @@
+# Interaction Log Schemas and Examples
+
+Canonical JSON Schemas (draft 2020-12) and matching examples for USAi interaction
+logs. Two format generations are represented here.
+
+## Current format (in production today)
+
+Content is inline on each streamed NDJSON event.
+
+| File | Purpose |
+|---|---|
+| [`interaction_raw_event_schema.json`](interaction_raw_event_schema.json) | RAW event, content inline |
+| [`interaction_raw_event_example.json`](interaction_raw_event_example.json) | Example RAW event |
+| [`interaction_redacted_event_schema.json`](interaction_redacted_event_schema.json) | REDACTED event, content inline |
+| [`interaction_redacted_event_example.json`](interaction_redacted_event_example.json) | Example REDACTED event |
+
+## Split format (upcoming — context-history split)
+
+Each request produces a small metadata event plus a separate S3 document holding
+the conversation content. Applies to the RAW stream; the REDACTED stream's
+behavior is not yet confirmed. Cutover date not yet published.
+
+| File | Purpose |
+|---|---|
+| [`interaction_raw_metadata_event_schema.json`](interaction_raw_metadata_event_schema.json) | Metadata event with `context_history_s3_key` |
+| [`interaction_raw_metadata_event_chat_example.json`](interaction_raw_metadata_event_chat_example.json) | Example metadata event, `source: "chat"` |
+| [`interaction_raw_metadata_event_api_example.json`](interaction_raw_metadata_event_api_example.json) | Example metadata event, `source: "api"` |
+| [`interaction_context_history_schema.json`](interaction_context_history_schema.json) | The content document at `context_history_s3_key` |
+| [`interaction_context_history_chat_example.json`](interaction_context_history_chat_example.json) | Example content document, chat traffic |
+| [`interaction_context_history_api_example.json`](interaction_context_history_api_example.json) | Example content document, API traffic |
+
+Narrative documentation, the field-by-field delta, and the consumer migration
+checklist are in
+[`../raw-vs-redacted-logs.md`](../raw-vs-redacted-logs.md#upcoming-change-context-history-split).
+
+## Note on artifact shape
+
+The metadata events are **NDJSON** — one JSON object per line in the delivered S3
+object. The `*_example.json` files here are pretty-printed single objects for
+readability; a real log file has one compact object per line.
+
+The context-history documents are **single JSON documents**, not NDJSON.
+
+## Validating a sample against these schemas
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install jsonschema
+```
+
+```python
+import json
+import jsonschema
+
+schema = json.load(open("interaction_raw_metadata_event_schema.json"))
+validator = jsonschema.Draft202012Validator(schema)
+
+with open("log.json") as f:                 # NDJSON from S3
+    for lineno, line in enumerate(f, 1):
+        for err in validator.iter_errors(json.loads(line)):
+            path = "/".join(str(p) for p in err.path) or "<root>"
+            print(f"line {lineno} [{path}]: {err.message}")
+```
+
+Note that these schemas do not set `additionalProperties: false`. Unknown fields
+are allowed so that a new platform field does not break tenant validation; run the
+loop above after any platform release to spot fields worth adopting.

--- a/log-access/examples/interaction_context_history_api_example.json
+++ b/log-access/examples/interaction_context_history_api_example.json
@@ -1,0 +1,29 @@
+{
+  "user_id": "local-api",
+  "prompt": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Hello"
+          }
+        ]
+      }
+    ]
+  },
+  "response": {
+    "choices": [
+      {
+        "content": "Hello! It's nice to meet you. Is there something I can help you with or would you like to chat?",
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 36,
+      "completion_tokens": 24,
+      "total_tokens": 60
+    }
+  }
+}

--- a/log-access/examples/interaction_context_history_chat_example.json
+++ b/log-access/examples/interaction_context_history_chat_example.json
@@ -1,0 +1,90 @@
+{
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "prompt": {
+    "messages": [
+      {
+        "role": "system",
+        "content": [
+          {
+            "type": "text",
+            "text": "### purpose\nYou are a helpful assistant that works for a government agency. You are the LLM model: {{current_model}}\nYou help users with general knowledge, problem-solving, coding, ..."
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Who is the current Administrator for the General Services Administration?"
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [],
+        "tool_calls": [
+          {
+            "index": 0,
+            "id": "call_skqaxWgd2tuOUlF468FNyG1W",
+            "type": "function",
+            "function": {
+              "name": "web_search",
+              "arguments": "{\"query\":\"current Administrator of the General Services Administration GSA Administrator\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "call_skqaxWgd2tuOUlF468FNyG1W",
+        "content": "[{\"title\": \"Administrator for the General Services Administration | GSA\", \"link\": \"https://www.gsa.gov/about-gsa/organization/administrator\", \"snippet\": \"May 21, 2026 ... Ed Forst. As Administrator, Ed Forst brings 40 years of experience in managing complex organizations. ...\"}]"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "web_search",
+          "description": "Get snippets and links from Google PSE search",
+          "parameters": {
+            "properties": {
+              "query": {
+                "description": "The query to pass to Google",
+                "title": "Query",
+                "type": "string"
+              },
+              "time_limit": {
+                "anyOf": [
+                  {
+                    "enum": ["d1", "w1", "m1", "y1"],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Restrict results to a specific time. Use \"d1\" for last 24h, \"w1\" for last week, \"m1\" for last month, or \"y1\" for last year.",
+                "title": "Time Limit"
+              }
+            },
+            "required": ["query"],
+            "title": "SearchQuery",
+            "type": "object"
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto"
+  },
+  "response": {
+    "choices": [
+      {
+        "content": "The current Administrator of the General Services Administration (GSA) is **Ed Forst** \u2014 also listed as **Edward C. Forst** on GSA materials.",
+        "finish_reason": "stop"
+      }
+    ]
+  }
+}

--- a/log-access/examples/interaction_context_history_schema.json
+++ b/log-access/examples/interaction_context_history_schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GSA-TTS/usai-onboarding/log-access/examples/interaction_context_history_schema.json",
+  "title": "USAi Interaction Context History Document (split format, post-cutover)",
+  "description": "Schema for the standalone S3 object that holds the full prompt/response content for one interaction event. This is a single JSON document (NOT newline-delimited). Its key is published on the corresponding firehose metadata event as context_history_s3_key. See interaction_raw_metadata_event_schema.json.",
+  "type": "object",
+  "required": ["user_id", "prompt", "response"],
+  "properties": {
+    "user_id": {
+      "type": "string",
+      "description": "User identifier, matching user_id on the metadata event."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for chat traffic; absent for stateless API requests."
+    },
+    "prompt": {
+      "type": "object",
+      "description": "Full, unredacted request payload.",
+      "required": ["messages"],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "enum": ["system", "user", "assistant", "tool"]
+              },
+              "content": {
+                "description": "Either a string (tool results) or a list of typed content parts. May be an empty array on assistant messages that only carry tool_calls.",
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Content part type, e.g. 'text'."
+                        },
+                        "text": { "type": "string" }
+                      }
+                    }
+                  }
+                ]
+              },
+              "tool_call_id": {
+                "type": "string",
+                "description": "Present on role='tool' messages; correlates with an earlier tool_calls[].id."
+              },
+              "tool_calls": {
+                "type": "array",
+                "description": "Present on role='assistant' messages that invoke tools.",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "type", "function"],
+                  "properties": {
+                    "index": { "type": "integer" },
+                    "id": { "type": "string" },
+                    "type": { "type": "string" },
+                    "function": {
+                      "type": "object",
+                      "required": ["name", "arguments"],
+                      "properties": {
+                        "name": { "type": "string" },
+                        "arguments": {
+                          "type": "string",
+                          "description": "JSON-encoded string of the tool arguments."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tool/function definitions supplied to the model.",
+          "items": {
+            "type": "object",
+            "required": ["type", "function"],
+            "properties": {
+              "type": { "type": "string" },
+              "function": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "description": { "type": "string" },
+                  "parameters": {
+                    "type": "object",
+                    "description": "JSON Schema describing the tool's arguments."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tool_choice": {
+          "type": "string",
+          "description": "Tool selection strategy, e.g. 'auto', 'none', 'required'."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Sampling temperature for the request, when supplied."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "description": "Full, unredacted response payload.",
+      "required": ["choices"],
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": { "type": "string" },
+              "finish_reason": { "type": "string" },
+              "tool_calls": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "index": { "type": "integer" },
+                    "id": { "type": "string" },
+                    "type": { "type": "string" },
+                    "function": {
+                      "type": "object",
+                      "properties": {
+                        "name": { "type": "string" },
+                        "arguments": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "usage": {
+          "type": "object",
+          "description": "Token usage. Optional here: for chat traffic usage is carried on the metadata event instead. Read usage from the metadata event first and fall back to this field.",
+          "properties": {
+            "prompt_tokens": { "type": "integer" },
+            "completion_tokens": { "type": "integer" },
+            "total_tokens": { "type": "integer" },
+            "latency_ms": { "type": ["integer", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/log-access/examples/interaction_raw_event_example.json
+++ b/log-access/examples/interaction_raw_event_example.json
@@ -1,0 +1,78 @@
+{
+  "event_id": "024f481f-8e11-42cc-bd23-e39e0596a6b2",
+  "event_time": "2026-07-23T13:04:51.300501+00:00",
+  "source": "api",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "api-key-abcdefghijk",
+  "request_id": "111e111c-3f65-47d8-abf0-c2ddf6c2f994",
+  "model": "claude-sonnet-4.6",
+  "platform_model_id": "inference-profile/us.anthropic.claude-sonnet-4-6",
+  "truncated": false,
+  "prompt": {
+    "messages": [
+      {
+        "role": "system",
+        "content": [
+          {
+            "type": "text",
+            "text": "You are Zoo, a highly skilled software engineer ... MARKDOWN RULES ... TOOL USE ..."
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "<task>Fix the bug in ...</task> ..."
+          }
+        ]
+      }
+    ],
+    "tool_choice": "auto",
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read_file",
+          "description": "Read the contents of a file ...",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": { "type": "string", "description": "..." },
+              "offset": { "type": "string", "description": "..." },
+              "limit": { "type": "string", "description": "..." }
+            },
+            "required": ["path"]
+          }
+        }
+      }
+    ]
+  },
+  "response": {
+    "choices": [
+      {
+        "content": "I'll start by reading the file ...",
+        "finish_reason": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "toolu_01ABC...",
+            "index": 0,
+            "type": "function",
+            "function": {
+              "name": "read_file",
+              "arguments": "{\"path\": \"src/main.py\", \"limit\": \"...\"}"
+            }
+          }
+        ]
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 18452,
+      "completion_tokens": 312,
+      "total_tokens": 18764,
+      "latency_ms": 4210
+    }
+  }
+}

--- a/log-access/examples/interaction_raw_event_schema.json
+++ b/log-access/examples/interaction_raw_event_schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "USAi Interaction Raw Firehose ChatCompletion Event (pre-cutover, inline content)",
+  "description": "Schema for a single line of the interaction-raw firehose JSONL export in the ORIGINAL single-object format, where prompt/response content is inline on the event. One JSON object per line (newline-delimited JSON). Unlike the redacted firehose, prompt/response are raw (not PII-redacted), include tool definitions, tool calls, and a platform_model_id. NOTE: this format is being replaced by the context-history split, in which content moves to a separate S3 object keyed by context_history_s3_key. For the new format see interaction_raw_metadata_event_schema.json and interaction_context_history_schema.json.",
+  "type": "object",
+  "required": [
+    "event_id",
+    "event_time",
+    "source",
+    "stream",
+    "kind",
+    "user_id",
+    "request_id",
+    "model",
+    "platform_model_id",
+    "prompt",
+    "response",
+    "truncated"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the event."
+    },
+    "event_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp, e.g. 2026-07-23T13:04:56.300501+00:00."
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the request. 'chat' for USAi Chat traffic, 'api' for direct API traffic."
+    },
+    "stream": {
+      "type": "boolean",
+      "description": "Whether the response was streamed."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Event kind, e.g. 'chat_completion'."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "User identifier. A user UUID for source='chat', or an api-key alias such as 'api-key-<uuid>' / 'local-api' for source='api'."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for source='chat'; absent for stateless source='api' requests."
+    },
+    "request_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the request."
+    },
+    "model": {
+      "type": "string",
+      "description": "Model alias, e.g. 'claude-sonnet-4.6'."
+    },
+    "platform_model_id": {
+      "type": "string",
+      "description": "Underlying platform model id, e.g. 'inference-profile/us.anthropic.claude-sonnet-4-6'."
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "Whether the stored content was truncated."
+    },
+    "prompt": {
+      "type": "object",
+      "description": "Raw request payload.",
+      "required": ["messages"],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role", "content"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "enum": ["system", "user", "assistant", "tool"]
+              },
+              "content": {
+                "description": "Either a string or a list of typed content parts.",
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Content part type, e.g. 'text'."
+                        },
+                        "text": { "type": "string" }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "tool_choice": {
+          "type": "string",
+          "description": "Tool selection strategy, e.g. 'auto', 'none', 'required'."
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tool/function definitions supplied to the model.",
+          "items": {
+            "type": "object",
+            "required": ["type", "function"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Tool type, e.g. 'function'."
+              },
+              "function": {
+                "type": "object",
+                "required": ["name", "parameters"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "description": { "type": "string" },
+                  "parameters": {
+                    "type": "object",
+                    "description": "JSON Schema (draft) describing the tool's arguments. Structure varies per tool: typically { type, properties, required }."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "description": "Raw response payload.",
+      "required": ["choices", "usage"],
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Model output text (may be empty when only tool_calls are returned)."
+              },
+              "finish_reason": {
+                "type": "string",
+                "description": "Reason generation stopped, e.g. 'stop', 'tool_calls'."
+              },
+              "tool_calls": {
+                "type": "array",
+                "description": "Tool/function calls emitted by the model.",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "type", "function"],
+                  "properties": {
+                    "id": { "type": "string" },
+                    "index": { "type": "integer" },
+                    "type": {
+                      "type": "string",
+                      "description": "e.g. 'function'."
+                    },
+                    "function": {
+                      "type": "object",
+                      "required": ["name", "arguments"],
+                      "properties": {
+                        "name": { "type": "string" },
+                        "arguments": {
+                          "type": "string",
+                          "description": "JSON-encoded string of the call arguments."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "usage": {
+          "type": "object",
+          "properties": {
+            "prompt_tokens": { "type": "integer" },
+            "completion_tokens": { "type": "integer" },
+            "total_tokens": { "type": "integer" },
+            "latency_ms": {
+              "type": ["integer", "null"],
+              "description": "End-to-end latency in milliseconds. Emitted as null when not measured."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/log-access/examples/interaction_raw_metadata_event_api_example.json
+++ b/log-access/examples/interaction_raw_metadata_event_api_example.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "631241ad-d6c3-4625-94a2-880196702bdd",
+  "event_time": "2026-07-23T17:52:47.953503+00:00",
+  "source": "api",
+  "stream": false,
+  "kind": "chat_completion",
+  "user_id": "local-api",
+  "request_id": "4323c79e-1b51-4c24-9fb8-f7ac6039b84f",
+  "model": "llama_4_maverick",
+  "platform_model_id": "inference-profile/us.meta.llama4-maverick-17b-instruct-v1:0",
+  "status": "success",
+  "context_history_s3_key": "api/local-api/631241ad-d6c3-4625-94a2-880196702bdd.json"
+}

--- a/log-access/examples/interaction_raw_metadata_event_chat_example.json
+++ b/log-access/examples/interaction_raw_metadata_event_chat_example.json
@@ -1,0 +1,20 @@
+{
+  "event_id": "fd0be7bb-48d2-4376-bd4d-774a965a779d",
+  "event_time": "2026-07-23T17:46:33.705182+00:00",
+  "source": "chat",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "request_id": "20b7b796-dafa-415f-a5ae-a753678cef2c",
+  "model": "gpt-5.5",
+  "platform_model_id": "gpt-5.5-DefaultV2",
+  "usage": {
+    "prompt_tokens": 2237,
+    "completion_tokens": 38,
+    "total_tokens": 2275,
+    "latency_ms": null
+  },
+  "status": "success",
+  "context_history_s3_key": "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json"
+}

--- a/log-access/examples/interaction_raw_metadata_event_schema.json
+++ b/log-access/examples/interaction_raw_metadata_event_schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GSA-TTS/usai-onboarding/log-access/examples/interaction_raw_metadata_event_schema.json",
+  "title": "USAi Interaction Raw Metadata Event (split format, post-cutover)",
+  "description": "Schema for a single line of the interaction-raw firehose JSONL export AFTER the context-history split. One JSON object per line (newline-delimited JSON). This event carries only request metadata and token usage; the prompt/response content lives in a separate S3 object identified by context_history_s3_key and described by interaction_context_history_schema.json. For the pre-cutover single-object format see interaction_raw_event_schema.json.",
+  "type": "object",
+  "required": [
+    "event_id",
+    "event_time",
+    "source",
+    "stream",
+    "kind",
+    "user_id",
+    "request_id",
+    "model",
+    "platform_model_id",
+    "status",
+    "context_history_s3_key"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the event. Also used as the final path segment of context_history_s3_key."
+    },
+    "event_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp, e.g. 2026-07-23T17:46:33.705182+00:00."
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the request. 'chat' for USAi Chat traffic, 'api' for direct API traffic.",
+      "examples": ["chat", "api"]
+    },
+    "stream": {
+      "type": "boolean",
+      "description": "Whether the response was streamed."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Event kind, e.g. 'chat_completion'."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "User identifier. A user UUID for source='chat', or an api-key alias such as 'api-key-<uuid>' / 'local-api' for source='api'."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for source='chat'; absent for stateless source='api' requests. Used as a path segment of context_history_s3_key for chat traffic."
+    },
+    "request_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the request."
+    },
+    "model": {
+      "type": "string",
+      "description": "Model alias, e.g. 'gpt-5.5', 'llama_4_maverick', 'claude-sonnet-4.6'."
+    },
+    "platform_model_id": {
+      "type": "string",
+      "description": "Underlying platform model id, e.g. 'gpt-5.5-DefaultV2' or 'inference-profile/us.meta.llama4-maverick-17b-instruct-v1:0'."
+    },
+    "status": {
+      "type": "string",
+      "description": "Outcome of the request, e.g. 'success'. Treat as an open string set; do not assume a closed enum."
+    },
+    "context_history_s3_key": {
+      "type": "string",
+      "description": "S3 object key of the context-history document holding the full prompt/response for this event. Chat traffic: 'chat/{conversation_id}/{event_id}.json'. API traffic: 'api/{user_id}/{event_id}.json'.",
+      "examples": [
+        "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json",
+        "api/local-api/631241ad-d6c3-4625-94a2-880196702bdd.json"
+      ]
+    },
+    "usage": {
+      "type": "object",
+      "description": "Token usage for the request. In the split format usage is emitted on the metadata event for chat traffic. For some API traffic usage is instead present inside the context-history document at response.usage, so consumers should read usage from the metadata event and fall back to the context document. See 'Token usage location' in raw-vs-redacted-logs.md.",
+      "properties": {
+        "prompt_tokens": { "type": "integer" },
+        "completion_tokens": { "type": "integer" },
+        "total_tokens": { "type": "integer" },
+        "latency_ms": {
+          "type": ["integer", "null"],
+          "description": "End-to-end latency in milliseconds. Emitted as null when not measured."
+        }
+      }
+    }
+  }
+}

--- a/log-access/examples/interaction_redacted_event_example.json
+++ b/log-access/examples/interaction_redacted_event_example.json
@@ -1,0 +1,47 @@
+{
+  "event_id": "6e111d4e-928a-40fa-8bd9-8448637e9a6a",
+  "event_time": "2026-04-28T06:01:22.670432+00:00",
+  "source": "api",
+  "stream": false,
+  "kind": "chat_completion",
+  "user_id": "api-key-abcd",
+  "request_id": "a29e5dc8-a5ff-426e-b127-3b3e7716b09c",
+  "model": "gemini-2.5-pro",
+  "truncated": false,
+  "prompt_redacted": {
+    "messages": [
+      {
+        "role": "system",
+        "content": [
+          {
+            "type": "text",
+            "text": "You are a Section 508 compliance expert. Analyze the document text ... Return ONLY valid JSON with these fields: {...}"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Analyze this text for Section 508 applicability:\n\nAPPLICABLE PROVISIONS AND CLAUSES ... contact <PHONE> ..."
+          }
+        ]
+      }
+    ],
+    "temperature": 0.0
+  },
+  "response_redacted": {
+    "choices": [
+      {
+        "content": "```json\n{\n  \"is_508_applicable\": false,\n  \"confidence_score\": 3,\n  \"key_eit_indicators\": [\"software\", \"hardware\", \"...\"],\n  \"applicability_explanation\": \"...\",\n  \"accessibility_considerations\": \"None\",\n  \"is_physical_only\": false,\n  \"has_explicit_508_mention\": false,\n  \"is_cots_product\": true,\n  \"ict_complexity\": \"Simple\"\n}\n```",
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 9848,
+      "completion_tokens": 206,
+      "total_tokens": 11855
+    }
+  }
+}

--- a/log-access/examples/interaction_redacted_event_schema.json
+++ b/log-access/examples/interaction_redacted_event_schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "USAI interaction - redacted s3 logs Schema (pre-cutover, inline content)",
+  "description": "Schema for a single line of the USAI redacted firehose JSONL export. The file contains one JSON object per line (newline-delimited JSON), each representing a redacted chat_completion event with inline redacted content. NOTE: the raw stream is moving to a context-history split (see interaction_raw_metadata_event_schema.json). Whether the redacted stream also splits is not yet confirmed; see 'Upcoming change' in raw-vs-redacted-logs.md.",
+  "type": "object",
+  "required": [
+    "event_id",
+    "event_time",
+    "source",
+    "stream",
+    "kind",
+    "user_id",
+    "request_id",
+    "model",
+    "truncated",
+    "prompt_redacted",
+    "response_redacted"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the event."
+    },
+    "event_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the event, e.g. 2026-04-28T06:01:22.670432+00:00."
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the request. 'chat' for USAi Chat traffic, 'api' for direct API traffic."
+    },
+    "stream": {
+      "type": "boolean",
+      "description": "Whether the response was streamed."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Event kind, e.g. 'chat_completion'."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "User identifier. A user UUID for source='chat', or an api-key alias such as 'api-key-<uuid>' / 'local-api' for source='api'."
+    },
+    "conversation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Conversation the request belongs to. Present for source='chat'; absent for stateless source='api' requests."
+    },
+    "request_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the request."
+    },
+    "model": {
+      "type": "string",
+      "description": "Model used, e.g. 'gemini-2.5-pro', 'gemini-2.5-flash'."
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "Whether the stored content was truncated."
+    },
+    "prompt_redacted": {
+      "type": "object",
+      "description": "PII-redacted request payload.",
+      "required": ["messages"],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role", "content"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "enum": ["system", "user", "assistant"]
+              },
+              "content": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Content part type, e.g. 'text'."
+                    },
+                    "text": {
+                      "type": "string",
+                      "description": "Text content. May contain redaction tokens such as <PHONE>."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Sampling temperature for the request."
+        }
+      }
+    },
+    "response_redacted": {
+      "type": "object",
+      "description": "PII-redacted response payload.",
+      "required": ["choices", "usage"],
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Model output text, often a fenced ```json block."
+              },
+              "finish_reason": {
+                "type": "string",
+                "description": "Reason generation stopped, e.g. 'stop'."
+              }
+            }
+          }
+        },
+        "usage": {
+          "type": "object",
+          "properties": {
+            "prompt_tokens": { "type": "integer" },
+            "completion_tokens": { "type": "integer" },
+            "total_tokens": { "type": "integer" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/log-access/examples/validate_examples.py
+++ b/log-access/examples/validate_examples.py
@@ -1,0 +1,43 @@
+"""Validate log-access example documents against their schemas.
+
+Static/local validation. Run:
+    /tmp/pr13/venv/bin/python log-access/examples/validate_examples.py
+"""
+import json
+import os
+import sys
+
+import jsonschema
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+PAIRS = [
+    ("interaction_raw_event_schema.json", "interaction_raw_event_example.json"),
+    ("interaction_redacted_event_schema.json", "interaction_redacted_event_example.json"),
+    ("interaction_raw_metadata_event_schema.json", "interaction_raw_metadata_event_chat_example.json"),
+    ("interaction_raw_metadata_event_schema.json", "interaction_raw_metadata_event_api_example.json"),
+    ("interaction_context_history_schema.json", "interaction_context_history_chat_example.json"),
+    ("interaction_context_history_schema.json", "interaction_context_history_api_example.json"),
+]
+
+
+def main():
+    failures = 0
+    for schema_name, example_name in PAIRS:
+        schema = json.load(open(os.path.join(HERE, schema_name)))
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+        doc = json.load(open(os.path.join(HERE, example_name)))
+        errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+        status = "OK  " if not errors else "FAIL"
+        print(f"{status} {example_name} -> {schema_name}")
+        for err in errors:
+            path = "/".join(str(p) for p in err.path) or "<root>"
+            print(f"       [{path}] {err.message}")
+        failures += len(errors)
+    print("\nfailures:", failures)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/log-access/log-access-guide.md
+++ b/log-access/log-access-guide.md
@@ -397,6 +397,14 @@ python consume_logs.py
 
 Log files are in **NDJSON** (Newline Delimited JSON) format, optionally gzip-compressed.
 
+> **⚠️ Upcoming change — context-history split.** The RAW stream is changing so that
+> conversation content is written to a **separate S3 object** rather than embedded in
+> the streamed event. Firehose delivery, bucket, and dated prefix stay the same, but
+> `prompt`, `response`, and `truncated` leave the event; `status`,
+> `context_history_s3_key`, and a top-level `usage` are added. See
+> [Context-history split](#context-history-split-upcoming) below and the
+> [migration checklist](raw-vs-redacted-logs.md#migration-checklist-for-consumers).
+
 ### File Naming Pattern
 
 ```
@@ -405,6 +413,14 @@ Log files are in **NDJSON** (Newline Delimited JSON) format, optionally gzip-com
 
 Example: `2026/01/28/10-30-00-abc123def456.json`
 
+After the context-history split there is a second, separately keyed artifact per
+request holding the conversation content:
+
+```
+chat/{conversation_id}/{event_id}.json      # source = "chat"
+api/{user_id}/{event_id}.json               # source = "api"
+```
+
 ### File Contents
 
 Each line is a JSON object representing one analytics event.
@@ -412,40 +428,127 @@ Each line is a JSON object representing one analytics event.
 **RAW logs contain:**
 ```json
 {
-  "event_id": "uuid",
-  "event_time": "2026-02-01T15:16:17Z",
-  "user_id": "uuid",
-  "chat_id": "uuid",
-  "prompt": {"content": "Full user question text"},
-  "response": {"content": "Full AI response text"},
-  "model": "google_vertex_manifold_pipeline.gemini-2.5-flash",
-  "latency_ms": 8044,
-  "tokens_prompt": 4,
-  "tokens_response": 1134
+  "event_id": "024f481f-8e11-42cc-bd23-e39e0596a6b2",
+  "event_time": "2026-07-23T13:04:51.300501+00:00",
+  "source": "api",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "api-key-abcdefghijk",
+  "request_id": "111e111c-3f65-47d8-abf0-c2ddf6c2f994",
+  "model": "claude-sonnet-4.6",
+  "platform_model_id": "inference-profile/us.anthropic.claude-sonnet-4-6",
+  "truncated": false,
+  "prompt": {
+    "messages": [
+      { "role": "user", "content": [ { "type": "text", "text": "Full user question text" } ] }
+    ],
+    "tool_choice": "auto",
+    "tools": [ { "type": "function", "function": { "name": "read_file", "parameters": { "type": "object" } } } ]
+  },
+  "response": {
+    "choices": [ { "content": "Full AI response text", "finish_reason": "stop" } ],
+    "usage": { "prompt_tokens": 18452, "completion_tokens": 312, "total_tokens": 18764, "latency_ms": 4210 }
+  }
 }
 ```
 
 **REDACTED logs contain:**
 ```json
 {
-  "event_id": "uuid",
-  "event_time": "2026-02-01T15:16:17Z",
-  "user_id": "uuid",
-  "chat_id": "uuid",
-  "prompt_redacted": {"content": "Let'<PERSON>. <PERSON>."},
-  "prompt_original_length": 157,
-  "prompt_redacted_length": 33,
-  "response_redacted": {"content": "Understood! <PERSON>..."},
-  "response_original_length": 686,
-  "response_redacted_length": 267,
-  "model": "google_vertex_manifold_pipeline.gemini-2.5-flash",
-  "latency_ms": 2595,
-  "tokens_prompt": 39,
-  "tokens_response": 171
+  "event_id": "6e111d4e-928a-40fa-8bd9-8448637e9a6a",
+  "event_time": "2026-04-28T06:01:22.670432+00:00",
+  "source": "api",
+  "stream": false,
+  "kind": "chat_completion",
+  "user_id": "api-key-abcd",
+  "request_id": "a29e5dc8-a5ff-426e-b127-3b3e7716b09c",
+  "model": "gemini-2.5-pro",
+  "truncated": false,
+  "prompt_redacted": {
+    "messages": [
+      { "role": "user", "content": [ { "type": "text", "text": "... contact <PHONE> ..." } ] }
+    ],
+    "temperature": 0.0
+  },
+  "response_redacted": {
+    "choices": [ { "content": "...", "finish_reason": "stop" } ],
+    "usage": { "prompt_tokens": 9848, "completion_tokens": 206, "total_tokens": 11855 }
+  }
 }
 ```
 
-**See [raw-vs-redacted-logs.md](raw-vs-redacted-logs.md) for detailed comparison.**
+**See [raw-vs-redacted-logs.md](raw-vs-redacted-logs.md) for detailed comparison, and [examples/](examples/) for the full JSON Schemas.**
+
+### Context-history split (upcoming)
+
+**Status:** announced by the platform team; cutover date not yet published. Applies
+to the RAW stream. Whether the REDACTED stream also splits is not yet confirmed.
+
+After the split, each request produces **two** artifacts.
+
+**1. Metadata event** — one NDJSON line in the same dated prefix as today
+(schema: [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json)):
+
+```json
+{
+  "event_id": "fd0be7bb-48d2-4376-bd4d-774a965a779d",
+  "event_time": "2026-07-23T17:46:33.705182+00:00",
+  "source": "chat",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "request_id": "20b7b796-dafa-415f-a5ae-a753678cef2c",
+  "model": "gpt-5.5",
+  "platform_model_id": "gpt-5.5-DefaultV2",
+  "usage": { "prompt_tokens": 2237, "completion_tokens": 38, "total_tokens": 2275, "latency_ms": null },
+  "status": "success",
+  "context_history_s3_key": "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json"
+}
+```
+
+**2. Context-history document** — a single JSON document (not NDJSON) at
+`context_history_s3_key`, holding `prompt` and `response`
+(schema: [`interaction_context_history_schema.json`](examples/interaction_context_history_schema.json)).
+
+**Fetching content for an event:**
+
+```bash
+KEY=$(head -1 log.json | jq -r '.context_history_s3_key')
+aws s3 cp s3://${BUCKET_NAME}/${KEY} ./context.json --region ${AWS_REGION}
+jq '.prompt.messages[-1], .response.choices[0].content' context.json
+```
+
+```python
+import json
+import boto3
+
+s3 = boto3.client("s3")
+
+def load_context(bucket, event):
+    """Fetch the conversation content for a split-format metadata event."""
+    key = event.get("context_history_s3_key")
+    if not key:
+        # Pre-cutover event: content is inline.
+        return {"prompt": event.get("prompt"), "response": event.get("response")}
+    body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+    return json.loads(body)
+
+def token_usage(bucket, event):
+    """usage lives on the metadata event; fall back to the context document."""
+    usage = event.get("usage") or {}
+    if usage.get("total_tokens") is None:
+        usage = (load_context(bucket, event).get("response") or {}).get("usage", {})
+    return usage
+```
+
+The helper above handles both formats, so you can deploy it before cutover.
+
+**IAM note:** if your read policy was scoped to the dated
+`{YEAR}/{MONTH}/{DAY}/*` prefix, it will not cover `chat/*` and `api/*`. Request an
+updated policy from [usai-security@gsa.gov](mailto:usai-security@gsa.gov) before
+cutover. Whether the context-history documents land in the same bucket is one of
+the [open questions](raw-vs-redacted-logs.md#open-questions).
 
 ### Processing Log Files
 

--- a/log-access/raw-vs-redacted-logs.md
+++ b/log-access/raw-vs-redacted-logs.md
@@ -2,6 +2,13 @@
 
 **Choose which log bucket to access based on your needs.**
 
+> **Upcoming change — context-history split.** The RAW interaction stream is
+> changing so that conversation content is written to a separate S3 object
+> instead of being embedded in the streamed event. Existing consumers must be
+> updated. See [Upcoming change: context-history split](#upcoming-change-context-history-split)
+> below for the new shapes, the migration steps, and what is still unconfirmed.
+> Everything above that section describes the format in production today.
+
 ---
 
 ## Two Options
@@ -11,23 +18,28 @@
 **Bucket naming:** `usai-{tenant}-core-production-interaction-redacted`
 
 **What you get:**
-- All performance metrics (latency, tokens, model)
-- PII masked with `<PERSON>` tags
-- User IDs, timestamps, session data
-- Original and redacted text lengths
+- Token metrics (`prompt_tokens`, `completion_tokens`, `total_tokens`) and `model`
+- PII masked with tokens like `<PERSON>`, `<PHONE>`, `<EMAIL>`
+- User IDs (`user_id`), `event_time`, `request_id`, `source`, `stream`, `truncated`
 
 **What you don't get:**
 - Actual conversation content
+- `latency_ms`, `platform_model_id`, or tool definitions/calls (raw only)
 
 **Example:**
 ```json
 {
+  "model": "gemini-2.5-pro",
   "prompt_redacted": {
-    "content": "Can <PERSON> help with <PERSON>?"
+    "messages": [
+      { "role": "user", "content": [ { "type": "text", "text": "Can you contact <PERSON> at <PHONE>?" } ] }
+    ],
+    "temperature": 0.0
   },
-  "tokens_prompt": 15,
-  "latency_ms": 2595,
-  "model": "google_vertex_manifold_pipeline.gemini-2.5-flash"
+  "response_redacted": {
+    "choices": [ { "content": "...", "finish_reason": "stop" } ],
+    "usage": { "prompt_tokens": 15, "completion_tokens": 42, "total_tokens": 57 }
+  }
 }
 ```
 
@@ -48,20 +60,29 @@
 
 **What you get:**
 - Everything from REDACTED bucket
-- Complete, unredacted conversation text
-- Full prompts and responses
+- Complete, unredacted conversation text (`prompt` / `response`)
+- `platform_model_id`, `latency_ms` (in `usage`)
+- Tool definitions (`prompt.tools`, `tool_choice`) and tool calls (`response.choices[].tool_calls`)
 
 **Example:**
 ```json
 {
+  "model": "claude-sonnet-4.6",
+  "platform_model_id": "inference-profile/us.anthropic.claude-sonnet-4-6",
   "prompt": {
-    "content": "Can you help me with a Power Query question?"
+    "messages": [
+      { "role": "user", "content": [ { "type": "text", "text": "Can you help me with a Power Query question?" } ] }
+    ],
+    "tool_choice": "auto",
+    "tools": [ { "type": "function", "function": { "name": "read_file", "parameters": { "type": "object" } } } ]
   },
   "response": {
-    "content": "Of course! I'd be happy to help..."
-  },
-  "tokens_prompt": 15,
-  "latency_ms": 2595
+    "choices": [
+      { "content": "Of course! I'd be happy to help...", "finish_reason": "tool_calls",
+        "tool_calls": [ { "id": "toolu_01ABC", "type": "function", "function": { "name": "read_file", "arguments": "{\"path\": \"src/main.py\"}" } } ] }
+    ],
+    "usage": { "prompt_tokens": 18452, "completion_tokens": 312, "total_tokens": 18764, "latency_ms": 4210 }
+  }
 }
 ```
 
@@ -98,12 +119,158 @@
 | Aspect | REDACTED | RAW |
 |--------|----------|-----|
 | **File size** | ~3-5 KB | ~10-20 KB |
-| **PII** | Removed | Present |
+| **PII** | Removed (`<PERSON>`, `<PHONE>`, ...) | Present |
 | **Content** | Masked | Full text |
-| **Metrics** | Complete | Complete |
-| **User IDs** | Yes | Yes |
-| **Timestamps** | Yes | Yes |
+| **Payload keys** | `prompt_redacted` / `response_redacted` | `prompt` / `response` |
+| **Token metrics** (`usage`) | Yes | Yes |
+| **`latency_ms`** | No | Yes (in `usage`) |
+| **`platform_model_id`** | No | Yes |
+| **Tools / tool_calls** | No | Yes |
+| **User IDs / Timestamps** | Yes | Yes |
 | **Security requirement** | Standard | Strict |
+
+---
+
+## Upcoming change: context-history split
+
+**Status:** announced by the platform team; cutover date not yet published.
+**Applies to:** the RAW interaction stream. Whether the REDACTED stream also
+splits is **not yet confirmed** — see [Open questions](#open-questions) below.
+
+### Why it is changing
+
+As conversation contexts grew, the logged items became too large for Kinesis to
+carry reliably. After the change, Kinesis still delivers one event per request to
+the same bucket and prefix layout, but that event no longer contains the chat/API
+content. The content is written separately to S3, and its location is published on
+the event as `context_history_s3_key`.
+
+Benefits:
+- Analytics that only need token usage or model selection process far less data.
+- No more failures when writing very large objects.
+
+### What each request produces after the split
+
+| Artifact | Delivered via | Location | Schema |
+|---|---|---|---|
+| **1. Metadata event** | Kinesis Firehose → S3 (unchanged prefix, NDJSON) | `{YEAR}/{MONTH}/{DAY}/{TIMESTAMP}-{UUID}.json` | [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json) |
+| **2. Context-history document** | Written directly to S3 (single JSON doc, not NDJSON) | `chat/{conversation_id}/{event_id}.json` or `api/{user_id}/{event_id}.json` | [`interaction_context_history_schema.json`](examples/interaction_context_history_schema.json) |
+
+### Metadata event (item 1)
+
+Content fields (`prompt`, `response`) and `truncated` are **gone**. New fields:
+`status`, `context_history_s3_key`, top-level `usage`, and `conversation_id` for
+chat traffic.
+
+```json
+{
+  "event_id": "fd0be7bb-48d2-4376-bd4d-774a965a779d",
+  "event_time": "2026-07-23T17:46:33.705182+00:00",
+  "source": "chat",
+  "stream": true,
+  "kind": "chat_completion",
+  "user_id": "9506e4f2-2b17-41e6-8ecc-b9c730b394c2",
+  "conversation_id": "e2065dd3-75ae-405c-aa81-2faef48853bd",
+  "request_id": "20b7b796-dafa-415f-a5ae-a753678cef2c",
+  "model": "gpt-5.5",
+  "platform_model_id": "gpt-5.5-DefaultV2",
+  "usage": { "prompt_tokens": 2237, "completion_tokens": 38, "total_tokens": 2275, "latency_ms": null },
+  "status": "success",
+  "context_history_s3_key": "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json"
+}
+```
+
+Full examples: [chat](examples/interaction_raw_metadata_event_chat_example.json),
+[api](examples/interaction_raw_metadata_event_api_example.json).
+
+### Context-history document (item 2)
+
+Fetched from the key above. Holds `prompt` (with `messages`, `tools`,
+`tool_choice`) and `response` (with `choices`), plus `user_id` and, for chat
+traffic, `conversation_id`.
+
+```json
+{
+  "user_id": "local-api",
+  "prompt": {
+    "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Hello" } ] } ]
+  },
+  "response": {
+    "choices": [ { "content": "Hello! It's nice to meet you...", "finish_reason": "stop" } ],
+    "usage": { "prompt_tokens": 36, "completion_tokens": 24, "total_tokens": 60 }
+  }
+}
+```
+
+Full examples: [chat](examples/interaction_context_history_chat_example.json),
+[api](examples/interaction_context_history_api_example.json).
+
+### Token usage location
+
+Read `usage` **from the metadata event first, then fall back to the
+context-history document** at `response.usage`. In the samples published by the
+platform team, chat traffic carries `usage` on the metadata event with no `usage`
+in the context document, while an API sample carried `usage` only inside the
+context document. Until that is reconciled, defensive reads are required:
+
+```bash
+# Token totals from metadata events, falling back is not possible in one pass —
+# read the metadata event value and treat null/absent as "fetch the context doc".
+jq -c '{event_id, model, total: (.usage.total_tokens // null),
+        context_history_s3_key}' log.json
+```
+
+```python
+usage = event.get("usage") or {}
+if not usage.get("total_tokens"):
+    ctx = json.load(s3.get_object(Bucket=bucket, Key=event["context_history_s3_key"])["Body"])
+    usage = ctx.get("response", {}).get("usage", {})
+```
+
+### Field-by-field delta (RAW stream)
+
+| Field | Before (inline) | After (split) |
+|---|---|---|
+| `prompt` / `response` | On the event | Moved to the context-history document |
+| `truncated` | Required on the event | Removed (the split makes truncation unnecessary) |
+| `usage` | `response.usage` | Top-level `usage` on the metadata event (fall back to `response.usage` in the context doc) |
+| `usage.latency_ms` | Integer | Integer **or `null`** |
+| `status` | Not present | New, e.g. `"success"` |
+| `context_history_s3_key` | Not present | New; pointer to the content object |
+| `conversation_id` | Undocumented but emitted for chat | Documented; also a path segment of the content key |
+| `event_id`, `event_time`, `source`, `stream`, `kind`, `user_id`, `request_id`, `model`, `platform_model_id` | Unchanged | Unchanged |
+
+### Migration checklist for consumers
+
+1. Stop requiring `prompt`, `response`, and `truncated` on streamed events.
+2. Read `usage` from the top level, with a fallback to the context document.
+3. Allow `usage.latency_ms` to be `null`.
+4. Add a second S3 `GetObject` for `context_history_s3_key` wherever you need
+   conversation content. Handle a missing or not-yet-written object with a retry.
+5. Update any jq/SQL/Glue/Athena projections that reference `.response.usage`,
+   `.prompt.messages`, or `truncated`.
+6. Confirm your IAM policy grants `s3:GetObject` on the `chat/*` and `api/*`
+   prefixes, not only the dated `{YEAR}/{MONTH}/{DAY}/*` prefix. If your policy
+   was scoped to the dated prefix, request an updated policy before cutover.
+
+### Open questions
+
+These are unresolved with the platform team; this guide will be updated when they
+are answered. Do not assume an answer.
+
+1. **Cutover date**, and whether old-format and new-format objects will coexist
+   in the same prefix during a transition window.
+2. **Canonical `usage` location** — metadata event, context document, or both.
+3. **Redacted stream** — does it split too, and is the context-history document
+   PII-redacted for the redacted tenant path?
+4. **Bucket and prefix** for context-history documents: same bucket as the
+   metadata events, or a separate bucket? This determines whether already-issued
+   tenant IAM policies need to change.
+5. **`status` values** — the full set, and whether `truncated` is fully retired.
+6. **Retention and SQS notifications** for context-history objects — are S3
+   event notifications emitted for them, or only for the firehose objects?
+
+Questions or migration help: [usai-security@gsa.gov](mailto:usai-security@gsa.gov).
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces #13 (and its follow-up #14) with **identical content in a single verified-signature commit**, so the base branch policy no longer blocks the merge.

#13 was approved but stuck on *"Commits must have verified signatures"* — it carried an unsigned commit, and my follow-up #14 added a second commit that GitHub could not attribute to an account (`reason: no_user`). Rather than rewrite someone else's commit, this PR squashes the exact same tree into one signed commit. @izzykayu is preserved as `Co-authored-by`.

**The file tree of this PR is byte-identical to the merged result of #13 + #14** — verified with `git write-tree`, not by eye.

## Contents

### Current format (originally @izzykayu's work in #13)
- Canonical raw/redacted JSON Schemas + examples under `log-access/examples/`
- Log Format examples corrected to `messages[].content[].text` and the real `usage` token names
- Raw-only fields documented (`platform_model_id`, `tools`/`tool_calls`)
- PII redaction field paths corrected; stale length-tracking fields dropped

### Upcoming context-history split
The raw stream is moving conversation content out of the streamed Kinesis event into a separate S3 object referenced by `context_history_s3_key`. Validating the current schemas against the platform team's published samples showed the raw schema **rejects** the new metadata event:

```
'prompt' is a required property
'response' is a required property
'truncated' is a required property
undocumented top-level fields: context_history_s3_key, conversation_id, status, usage
```

Also found: `usage.latency_ms` was typed `integer` but real samples emit `null`; `usage` relocates from `response.usage` to the top level, breaking the documented jq recipes; `source: "chat"` and `conversation_id` were emitted but undocumented.

- New `interaction_raw_metadata_event_schema.json` and `interaction_context_history_schema.json`, plus chat/api examples for each
- `examples/README.md` indexing both format generations; `examples/validate_examples.py` to keep them checkable
- Existing schemas marked pre-cutover; `usage.latency_ms` → `["integer","null"]`; `conversation_id` and the `chat`/`api` source values documented
- `raw-vs-redacted-logs.md`: field-by-field delta, token-usage read-order guidance, 6-step consumer migration checklist, open questions
- `log-access-guide.md`: second artifact's key patterns, a format-agnostic Python helper valid before and after cutover, IAM prefix implication
- `PII_REDACTION_COMPLETE.md`: documented redaction paths will not exist on the split event
- `log-access/README.md` + top-level `README.md`: pointers and post-split jq recipes

## Unresolved — needs platform team input

Documented as explicit open questions rather than guessed:

1. **Cutover date**, and whether both formats coexist in one prefix during transition.
2. **Canonical `usage` location.** The samples disagree: the chat sample has `usage` on the metadata event with none in the context doc; the API sample has it only at `response.usage` inside the context doc. Docs currently say read the metadata event first, then the context document — please confirm or correct.
3. **Redacted stream** — does it split too, and is the context document PII-redacted?
4. **Bucket/prefix for context documents.** Tenant IAM policies scoped to `{YEAR}/{MONTH}/{DAY}/*` will **not** cover `chat/*` and `api/*`, so already-issued credentials may break at cutover.
5. **`status` value set**, and whether `truncated` is fully retired.
6. **S3 event notifications** for context objects — emitted, or firehose objects only?

## Validation

**Level: static/local.** No live S3, Kinesis, or CI run.

- `log-access/examples/validate_examples.py` — 6/6 example-to-schema pairs pass, `failures: 0` (`jsonschema` Draft 2020-12). Also re-run against the files as fetched back from the remote branch, not just the local copies.
- Cross-generation checks: new schema accepts both split samples (0 errors); pre-cutover schema accepts the pre-cutover sample (0 errors); each rejects the other generation with exactly the documented errors; `usage.latency_ms: null` now accepted.
- Relative-link and anchor checker: 0 broken links across the 6 touched docs.
- Tree equality with the #13+#14 merge result confirmed via `git write-tree`.
- Commit `8b98f7f`: GitHub reports `verified: true`, `reason: valid`.

Not validated: that the split format matches what the pipeline will actually emit — the docs reflect the samples as published.

Closes #13.
