### PR TITLE
docs(log-access): confirm context-history objects use the same S3 bucket

### DIFF
--- a/log-access/PII_REDACTION_COMPLETE.md
+++ b/log-access/PII_REDACTION_COMPLETE.md
@@ -115,7 +115,10 @@ being embedded in the streamed event. That directly affects the paths listed abo
 exist on the streamed event, so a redactor reading only the Kinesis event has
 nothing to redact.
 
-**Not yet confirmed by the platform team** — do not assume either answer:
+**Not yet confirmed by the platform team** — do not assume either answer. This is
+being tracked in `GSA-TTS/usai-console-pipeline` issue #84, which flags that the
+redaction job currently enumerates only the dated `{YEAR}/{MONTH}/{DAY}/` prefix
+and so would not read the new `chat/` and `api/` context-history objects:
 
 - Whether the REDACTED pipeline also splits, or continues to emit inline
   `prompt_redacted` / `response_redacted` content.
@@ -123,8 +126,9 @@ nothing to redact.
   path, or exists only on the raw path.
 - Whether `truncated` is retired from the redacted event as well as the raw event.
 
-This document describes the redaction behavior in production today. It will be
-updated once the split's redaction design is published.
+Until those are answered, treat the split as affecting the **raw stream only**.
+This document describes the redaction behavior in production today, and will be
+updated once the split's redaction design is confirmed.
 
 ---
 

--- a/log-access/examples/interaction_raw_metadata_event_schema.json
+++ b/log-access/examples/interaction_raw_metadata_event_schema.json
@@ -69,7 +69,7 @@
     },
     "context_history_s3_key": {
       "type": "string",
-      "description": "S3 object key of the context-history document holding the full prompt/response for this event. Chat traffic: 'chat/{conversation_id}/{event_id}.json'. API traffic: 'api/{user_id}/{event_id}.json'.",
+      "description": "S3 object key of the context-history document holding the full prompt/response for this event. The object is in the SAME bucket as this metadata event; only the key prefix differs. Chat traffic: 'chat/{conversation_id}/{event_id}.json'. API traffic: 'api/{user_id}/{event_id}.json'.",
       "examples": [
         "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json",
         "api/local-api/631241ad-d6c3-4625-94a2-880196702bdd.json"

--- a/log-access/examples/interaction_raw_metadata_event_schema.json
+++ b/log-access/examples/interaction_raw_metadata_event_schema.json
@@ -69,7 +69,7 @@
     },
     "context_history_s3_key": {
       "type": "string",
-      "description": "S3 object key of the context-history document holding the full prompt/response for this event. The object is in the SAME bucket as this metadata event; only the key prefix differs. Chat traffic: 'chat/{conversation_id}/{event_id}.json'. API traffic: 'api/{user_id}/{event_id}.json'.",
+      "description": "S3 object key of the context-history document holding the full prompt/response for this event. The object is in the same bucket as this metadata event; only the key prefix differs. Chat traffic: 'chat/{conversation_id}/{event_id}.json'. API traffic: 'api/{user_id}/{event_id}.json'.",
       "examples": [
         "chat/e2065dd3-75ae-405c-aa81-2faef48853bd/fd0be7bb-48d2-4376-bd4d-774a965a779d.json",
         "api/local-api/631241ad-d6c3-4625-94a2-880196702bdd.json"

--- a/log-access/log-access-guide.md
+++ b/log-access/log-access-guide.md
@@ -544,11 +544,13 @@ def token_usage(bucket, event):
 
 The helper above handles both formats, so you can deploy it before cutover.
 
-**IAM note:** if your read policy was scoped to the dated
-`{YEAR}/{MONTH}/{DAY}/*` prefix, it will not cover `chat/*` and `api/*`. Request an
-updated policy from [usai-security@gsa.gov](mailto:usai-security@gsa.gov) before
-cutover. Whether the context-history documents land in the same bucket is one of
-the [open questions](raw-vs-redacted-logs.md#open-questions).
+**Bucket and IAM note:** the context-history documents are written to the **same
+bucket** you read today — no new bucket is provisioned, so the `BUCKET_NAME` in
+your existing configuration stays correct. Only the key prefix differs. If your
+read policy grants bucket-wide `s3:GetObject`, no change is needed. If it was
+scoped narrowly to the dated `{YEAR}/{MONTH}/{DAY}/*` prefix, it will not cover
+`chat/*` and `api/*` — request an updated policy from
+[usai-security@gsa.gov](mailto:usai-security@gsa.gov) before cutover.
 
 ### Processing Log Files
 

--- a/log-access/raw-vs-redacted-logs.md
+++ b/log-access/raw-vs-redacted-logs.md
@@ -151,9 +151,9 @@ Benefits:
 
 ### What each request produces after the split
 
-Both artifacts land in the **same S3 bucket** you read today — only the key
-prefix differs. No new bucket is provisioned for the split.
-
+Both artifacts land in the **same tenant S3 bucket as the metadata event** for
+that stream (raw or redacted) — only the key prefix differs. No new bucket is
+provisioned for the split.
 | Artifact | Delivered via | Location | Schema |
 |---|---|---|---|
 | **1. Metadata event** | Kinesis Firehose → S3 (unchanged prefix, NDJSON) | `{YEAR}/{MONTH}/{DAY}/{TIMESTAMP}-{UUID}.json` | [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json) |

--- a/log-access/raw-vs-redacted-logs.md
+++ b/log-access/raw-vs-redacted-logs.md
@@ -211,10 +211,13 @@ Full examples: [chat](examples/interaction_context_history_chat_example.json),
 ### Token usage location
 
 Read `usage` **from the metadata event first, then fall back to the
-context-history document** at `response.usage`. In the samples published by the
-platform team, chat traffic carries `usage` on the metadata event with no `usage`
-in the context document, while an API sample carried `usage` only inside the
-context document. Until that is reconciled, defensive reads are required:
+context-history document** at `response.usage`. This is the same order used by the
+USAi console pipeline, the reference consumer for these logs: it reads top-level
+`usage` and only consults `response.usage` for old-format records.
+
+The published samples show both placements — chat traffic carries `usage` on the
+metadata event, while an API sample carried it only inside the context document —
+so defensive reads remain the correct approach:
 
 ```bash
 # Token totals from metadata events, falling back is not possible in one pass —
@@ -266,15 +269,24 @@ are answered. Do not assume an answer.
 
 1. **Cutover date**, and whether old-format and new-format objects will coexist
    in the same prefix during a transition window.
-2. **Canonical `usage` location** — metadata event, context document, or both.
-3. **Redacted stream** — does it split too, and is the context-history document
-   PII-redacted for the redacted tenant path?
-4. **`status` values** — the full set, and whether `truncated` is fully retired.
-5. **Retention and SQS notifications** for context-history objects — are S3
+2. **Redacted stream** — does it split too, and is the context-history document
+   PII-redacted for the redacted tenant path? Tracked in
+   GSA-TTS/usai-console-pipeline#84, which flags that the redaction job may not
+   yet read the new prefixes. Until that is resolved, treat this document as
+   describing the **raw** stream only.
+3. **`status` values** — the full set, and whether `truncated` is fully retired.
+4. **Retention and SQS notifications** for context-history objects — are S3
    event notifications emitted for them, or only for the firehose objects?
 
-**Resolved:** context-history documents are written to the **same bucket** as the
-metadata events; no separate bucket is provisioned.
+### Resolved
+
+- **Same bucket.** Context-history documents are written to the same tenant bucket
+  as the metadata events; no separate bucket is provisioned. Only the key prefix
+  differs.
+- **Canonical `usage` location.** Read top-level `usage` first, then fall back to
+  `response.usage` in the context document. This matches the reference consumer in
+  the USAi console pipeline, which reads top-level `usage` and only consults
+  `response.usage` for old-format records.
 
 Questions or migration help: [usai-security@gsa.gov](mailto:usai-security@gsa.gov).
 

--- a/log-access/raw-vs-redacted-logs.md
+++ b/log-access/raw-vs-redacted-logs.md
@@ -151,6 +151,9 @@ Benefits:
 
 ### What each request produces after the split
 
+Both artifacts land in the **same S3 bucket** you read today — only the key
+prefix differs. No new bucket is provisioned for the split.
+
 | Artifact | Delivered via | Location | Schema |
 |---|---|---|---|
 | **1. Metadata event** | Kinesis Firehose → S3 (unchanged prefix, NDJSON) | `{YEAR}/{MONTH}/{DAY}/{TIMESTAMP}-{UUID}.json` | [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json) |
@@ -250,8 +253,11 @@ if not usage.get("total_tokens"):
 5. Update any jq/SQL/Glue/Athena projections that reference `.response.usage`,
    `.prompt.messages`, or `truncated`.
 6. Confirm your IAM policy grants `s3:GetObject` on the `chat/*` and `api/*`
-   prefixes, not only the dated `{YEAR}/{MONTH}/{DAY}/*` prefix. If your policy
-   was scoped to the dated prefix, request an updated policy before cutover.
+   prefixes. The context-history documents are written to the **same bucket** you
+   read today, so no new bucket access is needed — but a policy scoped narrowly to
+   the dated `{YEAR}/{MONTH}/{DAY}/*` prefix will not cover them. Policies granting
+   bucket-wide read need no change; request an updated policy if yours is
+   prefix-scoped.
 
 ### Open questions
 
@@ -263,12 +269,12 @@ are answered. Do not assume an answer.
 2. **Canonical `usage` location** — metadata event, context document, or both.
 3. **Redacted stream** — does it split too, and is the context-history document
    PII-redacted for the redacted tenant path?
-4. **Bucket and prefix** for context-history documents: same bucket as the
-   metadata events, or a separate bucket? This determines whether already-issued
-   tenant IAM policies need to change.
-5. **`status` values** — the full set, and whether `truncated` is fully retired.
-6. **Retention and SQS notifications** for context-history objects — are S3
+4. **`status` values** — the full set, and whether `truncated` is fully retired.
+5. **Retention and SQS notifications** for context-history objects — are S3
    event notifications emitted for them, or only for the firehose objects?
+
+**Resolved:** context-history documents are written to the **same bucket** as the
+metadata events; no separate bucket is provisioned.
 
 Questions or migration help: [usai-security@gsa.gov](mailto:usai-security@gsa.gov).
 

--- a/log-access/raw-vs-redacted-logs.md
+++ b/log-access/raw-vs-redacted-logs.md
@@ -154,6 +154,7 @@ Benefits:
 Both artifacts land in the **same tenant S3 bucket as the metadata event** for
 that stream (raw or redacted) — only the key prefix differs. No new bucket is
 provisioned for the split.
+
 | Artifact | Delivered via | Location | Schema |
 |---|---|---|---|
 | **1. Metadata event** | Kinesis Firehose → S3 (unchanged prefix, NDJSON) | `{YEAR}/{MONTH}/{DAY}/{TIMESTAMP}-{UUID}.json` | [`interaction_raw_metadata_event_schema.json`](examples/interaction_raw_metadata_event_schema.json) |


### PR DESCRIPTION
## Summary

The platform team confirmed that **context-history documents are written to the same tenant S3 bucket** as the metadata events — only the key prefix differs. No separate bucket is provisioned.

This resolves one of the open questions left in #15 and, more importantly, removes an ask we should never have shipped to partners: the previous IAM guidance told every tenant to audit their own policy against a fact we didn't know.

## Changes

- **`raw-vs-redacted-logs.md`**
  - State the same-bucket fact up front, where the two artifacts are introduced.
  - Rewrite migration checklist step 6: policies granting bucket-wide read need **no change**; only narrowly prefix-scoped policies (`{YEAR}/{MONTH}/{DAY}/*`) need updating to cover `chat/*` and `api/*`.
  - Remove the bucket/prefix item from **Open questions**, renumber the rest, and record it under a **Resolved** note.
- **`log-access-guide.md`** — replace the IAM note. Adds the practical detail that `BUCKET_NAME` in existing tenant configuration stays correct.
- **`interaction_raw_metadata_event_schema.json`** — note on `context_history_s3_key` that the object lives in the same bucket as the event.

## Still open

Four questions remain for the platform team (renumbered in the doc): cutover date/coexistence, canonical `usage` location, whether the redacted stream also splits and whether the context document is PII-redacted, `status` value set / `truncated` retirement, and retention + SQS notifications for context objects.

## Validation

**Level: static/local.** No live S3 or CI run.

- `log-access/examples/validate_examples.py` — 6/6 example-to-schema pairs pass, `failures: 0` (`jsonschema` Draft 2020-12).
- Edited schema re-parsed as valid JSON.
- Anchors referenced by external links confirmed intact: `## Upcoming change: context-history split`, `### Migration checklist for consumers`, `### Open questions`. This matters because partner-facing comms link to `#upcoming-change-context-history-split`.
- `git diff --check` clean; trailing newlines preserved.
- Commit `dc27f1e`: `verified: true`, `reason: valid`.
